### PR TITLE
chore: migrate docker registry from sakuracr.jp to ghcr.io/chiral-data

### DIFF
--- a/.github/workflows/build-changed-images.yml
+++ b/.github/workflows/build-changed-images.yml
@@ -1,0 +1,71 @@
+name: Build and Push Changed Images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/*/*/**"
+
+env:
+  REGISTRY: ghcr.io/chiral-data
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.changed.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect changed app directories
+        id: changed
+        run: |
+          DIRS=$(git diff --name-only HEAD~1 HEAD \
+            | grep '^apps/' \
+            | awk -F'/' '{print $2"/"$3}' \
+            | sort -u \
+            | jq -R . | jq -sc .)
+          echo "matrix=$DIRS" >> $GITHUB_OUTPUT
+          echo "Changed: $DIRS"
+
+  build:
+    needs: detect
+    if: ${{ needs.detect.outputs.matrix != '[]' && needs.detect.outputs.matrix != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        app_dir: ${{ fromJson(needs.detect.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Parse image name and tag
+        id: meta
+        run: |
+          FULLNAME=$(basename "${{ matrix.app_dir }}")
+          APP_NAME=$(echo "$FULLNAME" | cut -d'_' -f1)
+          DATE=$(echo "$FULLNAME" | cut -d'_' -f2-)
+          echo "image=${{ env.REGISTRY }}/${APP_NAME}:${DATE}" >> $GITHUB_OUTPUT
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/${{ matrix.app_dir }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.image }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,69 @@
+name: Build and Push Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_dir:
+        description: "App directory relative to apps/ (e.g. b/blast_2025_10_14)"
+        required: true
+        type: string
+      force_rebuild:
+        description: "Force rebuild even if image already exists"
+        required: false
+        default: false
+        type: boolean
+
+env:
+  REGISTRY: ghcr.io/chiral-data
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Parse image name and tag
+        id: meta
+        run: |
+          FULLNAME=$(basename "${{ inputs.app_dir }}")
+          APP_NAME=$(echo "$FULLNAME" | cut -d'_' -f1)
+          DATE=$(echo "$FULLNAME" | cut -d'_' -f2-)
+          echo "app_name=$APP_NAME" >> $GITHUB_OUTPUT
+          echo "date=$DATE" >> $GITHUB_OUTPUT
+          echo "image=${{ env.REGISTRY }}/${APP_NAME}:${DATE}" >> $GITHUB_OUTPUT
+
+      - name: Check if image already exists
+        id: check
+        if: ${{ !inputs.force_rebuild }}
+        run: |
+          if docker manifest inspect ${{ steps.meta.outputs.image }} > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Log in to ghcr.io
+        if: ${{ inputs.force_rebuild || steps.check.outputs.exists != 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        if: ${{ inputs.force_rebuild || steps.check.outputs.exists != 'true' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/${{ inputs.app_dir }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+
+      - name: Skip (image already exists)
+        if: ${{ !inputs.force_rebuild && steps.check.outputs.exists == 'true' }}
+        run: echo "Image ${{ steps.meta.outputs.image }} already exists, skipping build."

--- a/apps/README.md
+++ b/apps/README.md
@@ -2,11 +2,11 @@
 
 ## How to use
 
-Application container images are hosted on our private registry at `chiral.sakuracr.jp`.
+Application container images are hosted on our public registry at `ghcr.io/chiral-data`.
 To pull a specific application image, use the following format:
 
 ```bash
-docker pull chiral.sakuracr.jp/<app_name>:<date_tag>
+docker pull ghcr.io/chiral-data/<app_name>:<date_tag>
 ```
 
 Where:
@@ -17,7 +17,7 @@ Where:
   **Example:** To pull the `gromacs` application image using the current tag:
 
 ```bash
-docker pull chiral.sakuracr.jp:/gromacs:2025_09_05
+docker pull ghcr.io/chiral-data/gromacs:2025_09_05
 ```
 
 ## How to build a new image

--- a/apps/applications.json
+++ b/apps/applications.json
@@ -10,7 +10,7 @@
       "description": "Protein structure prediction using deep learning",
       "long_description": "Boltz is an advanced tool for predicting protein structures using state-of-the-art deep learning models. It leverages CUDA acceleration for fast inference and includes pre-downloaded model weights for immediate use.",
       "base_image": "nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04",
-      "registry": "chiral.sakuracr.jp",
+      "registry": "ghcr.io/chiral-data",
       "image_path": "/boltz:2025_09_05",
       "tags": ["protein", "ml", "gpu", "structure-prediction"],
       "requirements": {
@@ -28,7 +28,7 @@
       "description": "Molecular dynamics simulation package",
       "long_description": "GROMACS is a versatile package for molecular dynamics simulations, primarily designed for biochemical molecules. It provides high performance through GPU acceleration and optimized algorithms.",
       "base_image": "nvcr.io/hpc/gromacs:2023.2",
-      "registry": "chiral.sakuracr.jp",
+      "registry": "ghcr.io/chiral-data",
       "image_path": "/gromacs:2025_09_05",
       "tags": ["simulation", "molecular-dynamics", "hpc", "gpu"],
       "requirements": {
@@ -46,7 +46,7 @@
       "description": "Basic Local Alignment Search Tool",
       "long_description": "BLAST finds regions of similarity between biological sequences. The program compares nucleotide or protein sequences to sequence databases and calculates the statistical significance of matches.",
       "base_image": "ubuntu:22.04",
-      "registry": "chiral.sakuracr.jp",
+      "registry": "ghcr.io/chiral-data",
       "image_path": "/blast:2025_10_14",
       "tags": ["alignment", "sequence", "bioinformatics"],
       "requirements": {
@@ -64,7 +64,7 @@
       "description": "Message passing neural network for protein design",
       "long_description": "ProteinMPNN is a deep learning method for computational protein design. It uses message passing neural networks to predict amino acid sequences that will fold into desired protein structures.",
       "base_image": "nvidia/cuda:11.8.0-runtime-ubuntu22.04",
-      "registry": "chiral.sakuracr.jp",
+      "registry": "ghcr.io/chiral-data",
       "image_path": "/proteinmpnn:2025_09_10",
       "tags": ["protein", "design", "ml", "gpu"],
       "requirements": {
@@ -82,7 +82,7 @@
       "description": "Diffusion-based protein structure generation",
       "long_description": "RFdiffusion2 uses denoising diffusion probabilistic models to generate novel protein structures. It can design proteins with specific functional properties and structural motifs.",
       "base_image": "nvidia/cuda:12.0.0-runtime-ubuntu22.04",
-      "registry": "chiral.sakuracr.jp",
+      "registry": "ghcr.io/chiral-data",
       "image_path": "/rfdiffusion2:2025_09_19",
       "tags": ["protein", "diffusion", "generation", "gpu"],
       "requirements": {
@@ -100,7 +100,7 @@
       "description": "RNA secondary structure prediction using deep learning",
       "long_description": "UFold is a deep learning-based method for predicting RNA secondary structure from sequence. It uses a U-Net inspired architecture to directly predict base pairing probabilities.",
       "base_image": "nvidia/cuda:11.3.0-runtime-ubuntu20.04",
-      "registry": "chiral.sakuracr.jp",
+      "registry": "ghcr.io/chiral-data",
       "image_path": "/ufold:2025_09_18",
       "tags": ["rna", "structure", "ml", "gpu"],
       "requirements": {
@@ -118,7 +118,7 @@
       "description": "RNA-RNA interaction prediction",
       "long_description": "IntaRNA efficiently predicts RNA-RNA interactions, considering both hybridization and accessibility. It uses dynamic programming algorithms for accurate interaction site prediction.",
       "base_image": "ubuntu:22.04",
-      "registry": "chiral.sakuracr.jp",
+      "registry": "ghcr.io/chiral-data",
       "image_path": "/intarna:2025_09_18",
       "tags": ["rna", "interaction", "prediction"],
       "requirements": {
@@ -136,7 +136,7 @@
       "description": "RNA-small molecule binding prediction",
       "long_description": "RNAmigos2 predicts RNA-small molecule interactions using graph neural networks. It enables virtual screening of compounds for RNA-targeted drug discovery.",
       "base_image": "nvidia/cuda:11.6.0-runtime-ubuntu20.04",
-      "registry": "chiral.sakuracr.jp",
+      "registry": "ghcr.io/chiral-data",
       "image_path": "/rnamigos2:2025_09_19",
       "tags": ["rna", "ligand", "ml", "gpu", "drug-discovery"],
       "requirements": {
@@ -154,7 +154,7 @@
       "description": "Free energy calculation for protein-ligand binding",
       "long_description": "FreeBindCraft performs accurate free energy calculations for protein-ligand complexes. It combines molecular dynamics simulations with advanced sampling techniques.",
       "base_image": "nvidia/cuda:11.8.0-runtime-ubuntu22.04",
-      "registry": "chiral.sakuracr.jp",
+      "registry": "ghcr.io/chiral-data",
       "image_path": "/freebindcraft:2025_09_19",
       "tags": ["protein", "ligand", "free-energy", "gpu"],
       "requirements": {
@@ -172,7 +172,7 @@
       "description": "MicroRNA target prediction tool",
       "long_description": "RNAhybrid is a tool for finding the minimum free energy hybridization of a long and a short RNA. It is particularly useful for microRNA target prediction.",
       "base_image": "ubuntu:22.04",
-      "registry": "chiral.sakuracr.jp",
+      "registry": "ghcr.io/chiral-data",
       "image_path": "/rnahybrid:2025_10_14",
       "tags": ["rna", "mirna", "target-prediction"],
       "requirements": {
@@ -190,7 +190,7 @@
       "description": "AI-based protein/peptide binder design using generative diffusion",
       "long_description": "BoltzGen designs protein and peptide binders using generative diffusion models. It supports antibody (Fab) and peptide binder design with scaffold libraries and de novo generation, including confidence scoring and binding affinity prediction.",
       "base_image": "nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04",
-      "registry": "chiral.sakuracr.jp",
+      "registry": "ghcr.io/chiral-data",
       "image_path": "/boltzgen:2026_02_13",
       "tags": ["protein", "design", "binder", "ml", "gpu"],
       "requirements": {
@@ -208,7 +208,7 @@
       "description": "Report generator for Boltz-2 and BoltzGen results",
       "long_description": "Generates interactive HTML dashboards for protein structure prediction (Boltz-2) and binder design (BoltzGen) results. Includes quality assessment, confidence plots, and model ranking tables.",
       "base_image": "python:3.8",
-      "registry": "chiral.sakuracr.jp",
+      "registry": "ghcr.io/chiral-data",
       "image_path": "/boltz_report:2026_02_13",
       "tags": ["reporting", "visualization", "dashboard"],
       "requirements": {

--- a/apps/build.sh
+++ b/apps/build.sh
@@ -2,7 +2,7 @@
 #
 set -e
 
-REGISTRY_URL="chiral.sakuracr.jp"
+REGISTRY_URL="ghcr.io/chiral-data"
 FORCE_REBUILD=false
 
 # Parse command line arguments

--- a/jobs/g/gromacs/benchmark/@job.toml
+++ b/jobs/g/gromacs/benchmark/@job.toml
@@ -1,7 +1,7 @@
 use_gpu = true
 
 [container]
-docker_image = "chiral.sakuracr.jp/gromacs:2025_11_12"
+docker_image = "ghcr.io/chiral-data/gromacs:2025_11_12"
 
 [scripts]
 

--- a/workflows/structure_prediction/README.md
+++ b/workflows/structure_prediction/README.md
@@ -138,7 +138,7 @@ These examples showcase:
 4. **Documentation** → Generate analysis reports for Nobel Prize connections
 
 ## Container Information
-**Container Image**: `chiral.sakuracr.jp/boltz_dok_nvidia_2`
+**Container Image**: `ghcr.io/chiral-data/boltz_dok_nvidia_2`
 - Boltz-2 AI structure prediction model
 - NVIDIA GPU acceleration support
 - Includes MSA server connectivity
@@ -157,10 +157,10 @@ cd ../../2_antibody/inputs && ./job_script.sh
 ## Container Usage
 ```bash
 # Pull container (if needed)
-singularity pull chiral.sakuracr.jp/boltz_dok_nvidia_2
+singularity pull ghcr.io/chiral-data/boltz_dok_nvidia_2
 
 # Run prediction manually
-singularity exec --nv chiral.sakuracr.jp/boltz_dok_nvidia_2 \
+singularity exec --nv ghcr.io/chiral-data/boltz_dok_nvidia_2 \
     python3 -m boltz.main predict spike_rbd.fasta \
     --use_msa_server --output_format pdb
 ```
@@ -172,7 +172,7 @@ singularity exec --nv chiral.sakuracr.jp/boltz_dok_nvidia_2 \
 **Command Used:**
 ```bash
 cd /home/ubuntu/chiral/container-images-for-potter/sept_workflows/2_structure_prediction/1_mRNA/inputs
-docker run --rm --gpus all -v $(pwd):/workspace -w /workspace chiral.sakuracr.jp/boltz_dok_nvidia_2:latest ./job_script.sh
+docker run --rm --gpus all -v $(pwd):/workspace -w /workspace ghcr.io/chiral-data/boltz_dok_nvidia_2:latest ./job_script.sh
 ```
 
 **Issues Found & Fixes:**

--- a/workflows/workflow-001-wip/01_boltz/.chiral/job.toml
+++ b/workflows/workflow-001-wip/01_boltz/.chiral/job.toml
@@ -1,6 +1,6 @@
 use_gpu = true
 
 [container]
-docker_image = "chiral.sakuracr.jp/boltz:2025_09_05"
+docker_image = "ghcr.io/chiral-data/boltz:2025_09_05"
 
 [scripts]

--- a/workflows/workflow-002/01-download/.chiral/job.toml
+++ b/workflows/workflow-002/01-download/.chiral/job.toml
@@ -3,7 +3,7 @@ description = "Downloads compound library from Zenodo"
 outputs = ["constructed_library/*.sdf"]
 
 [container]
-image = "chiral.sakuracr.jp/smina:2025_10_17_v2"
+image = "ghcr.io/chiral-data/smina:2025_10_17_v2"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-002/02-prepare/.chiral/job.toml
+++ b/workflows/workflow-002/02-prepare/.chiral/job.toml
@@ -3,7 +3,7 @@ description = "Downloads and prepares target protein structure"
 outputs = ["*.pdb", "*.pqr", "config.txt"]
 
 [container]
-image = "chiral.sakuracr.jp/smina:2025_10_17_v2"
+image = "ghcr.io/chiral-data/smina:2025_10_17_v2"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-002/03-screening/.chiral/job.toml
+++ b/workflows/workflow-002/03-screening/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*.pdb", "config.txt", "*.sdf"]
 outputs = ["docking_results/*.sdf", "docking_results/*.txt"]
 
 [container]
-image = "chiral.sakuracr.jp/smina:2025_10_17_v2"
+image = "ghcr.io/chiral-data/smina:2025_10_17_v2"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-002/04-report/.chiral/job.toml
+++ b/workflows/workflow-002/04-report/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*.txt", "*.sdf", "*.pdb"]
 outputs = ["results/*.txt", "results/*.sdf", "results/*.pdb"]
 
 [container]
-image = "chiral.sakuracr.jp/smina:2025_10_17_v2"
+image = "ghcr.io/chiral-data/smina:2025_10_17_v2"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-002/README.md
+++ b/workflows/workflow-002/README.md
@@ -104,7 +104,7 @@ Analyzes results and generates rankings:
 
 ## Container
 
-All stages use: `chiral.sakuracr.jp/smina:2025_10_17_v2`
+All stages use: `ghcr.io/chiral-data/smina:2025_10_17_v2`
 
 ## Interpreting Results
 

--- a/workflows/workflow-003/1-download-pdb/.chiral/job.toml
+++ b/workflows/workflow-003/1-download-pdb/.chiral/job.toml
@@ -3,7 +3,7 @@ description = "Download a PDB file from the RCSB Protein Data Bank."
 outputs = ["*.pdb"]
 
 [container]
-image = "chiral.sakuracr.jp/smina:2025_11_06"
+image = "ghcr.io/chiral-data/smina:2025_11_06"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-003/2-protein-preparation/.chiral/job.toml
+++ b/workflows/workflow-003/2-protein-preparation/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*.pdb"]
 outputs = ["*.pdb"]
 
 [container]
-image = "chiral.sakuracr.jp/smina:2025_11_06"
+image = "ghcr.io/chiral-data/smina:2025_11_06"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-003/3-ligand-extraction/.chiral/job.toml
+++ b/workflows/workflow-003/3-ligand-extraction/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*.pdb"]
 outputs = ["*.sdf"]
 
 [container]
-image = "chiral.sakuracr.jp/smina:2025_11_06"
+image = "ghcr.io/chiral-data/smina:2025_11_06"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-003/4-ligand-modification/.chiral/job.toml
+++ b/workflows/workflow-003/4-ligand-modification/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*.sdf"]
 outputs = ["ligand_library", "variants.svg"]
 
 [container]
-image = "chiral.sakuracr.jp/smina:2025_11_06"
+image = "ghcr.io/chiral-data/smina:2025_11_06"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-003/5-in-silico-screening/.chiral/job.toml
+++ b/workflows/workflow-003/5-in-silico-screening/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*.pdb", "ligand_library"]
 outputs = ["docking_results", "results"]
 
 [container]
-image = "chiral.sakuracr.jp/smina:2025_11_06"
+image = "ghcr.io/chiral-data/smina:2025_11_06"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-003/6-report/.chiral/job.toml
+++ b/workflows/workflow-003/6-report/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["docking_results", "results"]
 outputs = ["results"]
 
 [container]
-image = "chiral.sakuracr.jp/smina:2025_11_06"
+image = "ghcr.io/chiral-data/smina:2025_11_06"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-005/01-data-preparation/.chiral/job.toml
+++ b/workflows/workflow-005/01-data-preparation/.chiral/job.toml
@@ -3,7 +3,7 @@ description = "Ingest raw SMILES data, compute physicochemical descriptors"
 outputs = ["outputs/descriptors.csv", "outputs/data.json", "outputs/report.html"]
 
 [container]
-image = "chiral.sakuracr.jp/qsar:20260107_v1"
+image = "ghcr.io/chiral-data/qsar:20260107_v1"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-005/02-feature-engineering/.chiral/job.toml
+++ b/workflows/workflow-005/02-feature-engineering/.chiral/job.toml
@@ -5,7 +5,7 @@ inputs = ["descriptors.csv"]
 outputs = ["outputs/processed_data.npz", "outputs/scaler.pkl", "outputs/ad_stats.json", "outputs/data.json", "outputs/report.html"]
 
 [container]
-image = "chiral.sakuracr.jp/qsar:20260107_v1"
+image = "ghcr.io/chiral-data/qsar:20260107_v1"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-005/03-model-training/.chiral/job.toml
+++ b/workflows/workflow-005/03-model-training/.chiral/job.toml
@@ -5,7 +5,7 @@ inputs = ["processed_data.npz"]
 outputs = ["outputs/model.h5", "outputs/data.json", "outputs/report.html"]
 
 [container]
-image = "chiral.sakuracr.jp/qsar:20260107_v1"
+image = "ghcr.io/chiral-data/qsar:20260107_v1"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-005/04-prediction/.chiral/job.toml
+++ b/workflows/workflow-005/04-prediction/.chiral/job.toml
@@ -5,7 +5,7 @@ inputs = ["scaler.pkl", "ad_stats.json", "model.h5"]
 outputs = ["outputs/data.json", "outputs/report.html", "outputs/predictions.csv"]
 
 [container]
-image = "chiral.sakuracr.jp/qsar:20260107_v1"
+image = "ghcr.io/chiral-data/qsar:20260107_v1"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-005/04-prediction/start_server.ps1
+++ b/workflows/workflow-005/04-prediction/start_server.ps1
@@ -3,7 +3,7 @@
 
 # Configuration
 $Port = "5000"
-$Image = "chiral.sakuracr.jp/qsar:20260107_v1"
+$Image = "ghcr.io/chiral-data/qsar:20260107_v1"
 
 # Determine paths dynamically
 # This allows running the script from anywhere (root or inside directory)

--- a/workflows/workflow-007/01-download/.chiral/job.toml
+++ b/workflows/workflow-007/01-download/.chiral/job.toml
@@ -8,7 +8,7 @@ default = "1FME, 2RH1, 4TOS"
 hint = "Comma-separated PDB IDs to download and analyze (e.g., 4TOS, 1FME, 2RH1)"
 
 [container]
-image = "chiral.sakuracr.jp/pocketeer:2025_12_08"
+image = "ghcr.io/chiral-data/pocketeer:2025_12_08"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-007/02-pocket/.chiral/job.toml
+++ b/workflows/workflow-007/02-pocket/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*.pdb", "*.json"]
 outputs = ["*.pdb", "*.json"]
 
 [container]
-image = "chiral.sakuracr.jp/pocketeer:2025_12_08"
+image = "ghcr.io/chiral-data/pocketeer:2025_12_08"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-007/03-visualize/.chiral/job.toml
+++ b/workflows/workflow-007/03-visualize/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*.pdb", "*.json"]
 outputs = ["*.html", "*.gif"]
 
 [container]
-image = "chiral.sakuracr.jp/pocketeer:2025_12_08"
+image = "ghcr.io/chiral-data/pocketeer:2025_12_08"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-008/01-data-ingestion-and-preprocessing/.chiral/job.toml
+++ b/workflows/workflow-008/01-data-ingestion-and-preprocessing/.chiral/job.toml
@@ -3,7 +3,7 @@ description = "Load raw data, standardize amino acid concentrations, and prepare
 outputs = ["data_standardized.pkl", "aa_cols.txt"]
 
 [container]
-image = "chiral.sakuracr.jp/proteomics:2025_12_31"
+image = "ghcr.io/chiral-data/proteomics:2025_12_31"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-008/02-cohort-demographics/.chiral/job.toml
+++ b/workflows/workflow-008/02-cohort-demographics/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["data_standardized.pkl"]
 outputs = ["Table1_Demographics.png", "Table2_MS_MG_Demographics.png", "demographics_data.json", "demographics.html"]
 
 [container]
-image = "chiral.sakuracr.jp/proteomics:2025_12_31"
+image = "ghcr.io/chiral-data/proteomics:2025_12_31"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-008/03-ms-pathology-overview/.chiral/job.toml
+++ b/workflows/workflow-008/03-ms-pathology-overview/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["data_standardized.pkl", "aa_cols.txt"]
 outputs = ["Fig1A_MS_vs_Control.png", "Fig1B_MS_Subtypes.png", "pathology_data.json", "pathology.html"]
 
 [container]
-image = "chiral.sakuracr.jp/proteomics:2025_12_31"
+image = "ghcr.io/chiral-data/proteomics:2025_12_31"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-008/04-clinical-confounders-and-validation/.chiral/job.toml
+++ b/workflows/workflow-008/04-clinical-confounders-and-validation/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["data_standardized.pkl", "aa_cols.txt"]
 outputs = ["Fig2A_Age_Grid.png", "Fig2B_Duration_Grid.png", "Fig2C_EDSS_Grid.png", "confounders_data.json", "confounders.html"]
 
 [container]
-image = "chiral.sakuracr.jp/proteomics:2025_12_31"
+image = "ghcr.io/chiral-data/proteomics:2025_12_31"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-008/05-ms-vs-mg-autoimmune-comparison/.chiral/job.toml
+++ b/workflows/workflow-008/05-ms-vs-mg-autoimmune-comparison/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["data_standardized.pkl", "aa_cols.txt"]
 outputs = ["Fig3_MS_MG_vs_Control.png", "autoimmune_data.json", "autoimmune.html"]
 
 [container]
-image = "chiral.sakuracr.jp/proteomics:2025_12_31"
+image = "ghcr.io/chiral-data/proteomics:2025_12_31"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-008/06-differential-diagnosis-biomarkers/.chiral/job.toml
+++ b/workflows/workflow-008/06-differential-diagnosis-biomarkers/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["data_standardized.pkl"]
 outputs = ["Fig4_Specific_Diffs.png", "Fig5_Female_Specific.png", "biomarkers_data.json", "biomarkers.html"]
 
 [container]
-image = "chiral.sakuracr.jp/proteomics:2025_12_31"
+image = "ghcr.io/chiral-data/proteomics:2025_12_31"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-008/07-metabolic-network-clustering/.chiral/job.toml
+++ b/workflows/workflow-008/07-metabolic-network-clustering/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["data_standardized.pkl", "aa_cols.txt"]
 outputs = ["Fig6_Corr_MS_MG.png", "Fig7_Corr_Control.png", "clustering_data.json", "clustering.html"]
 
 [container]
-image = "chiral.sakuracr.jp/proteomics:2025_12_31"
+image = "ghcr.io/chiral-data/proteomics:2025_12_31"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-008/08-global-metabolic-load-analysis/.chiral/job.toml
+++ b/workflows/workflow-008/08-global-metabolic-load-analysis/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["data_standardized.pkl"]
 outputs = ["Fig8_TotalAA_Type.png", "metabolic_load_data.json", "metabolic_load.html"]
 
 [container]
-image = "chiral.sakuracr.jp/proteomics:2025_12_31"
+image = "ghcr.io/chiral-data/proteomics:2025_12_31"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-008/09-subtype-trajectories/.chiral/job.toml
+++ b/workflows/workflow-008/09-subtype-trajectories/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["data_standardized.pkl", "aa_cols.txt"]
 outputs = ["Fig9_Duration_Grid.png", "trajectories_data.json", "trajectories.html"]
 
 [container]
-image = "chiral.sakuracr.jp/proteomics:2025_12_31"
+image = "ghcr.io/chiral-data/proteomics:2025_12_31"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-008/10-clinical-mimicry-test-rrms-vs-mg/.chiral/job.toml
+++ b/workflows/workflow-008/10-clinical-mimicry-test-rrms-vs-mg/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["data_standardized.pkl", "aa_cols.txt"]
 outputs = ["Fig10_TotalAA_RRMS_MG.png", "Fig11_RRMS_vs_MG_Grid.png", "mimicry_data.json", "mimicry.html"]
 
 [container]
-image = "chiral.sakuracr.jp/proteomics:2025_12_31"
+image = "ghcr.io/chiral-data/proteomics:2025_12_31"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-008/11-pathway-coherence-analysis/.chiral/job.toml
+++ b/workflows/workflow-008/11-pathway-coherence-analysis/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["data_standardized.pkl", "aa_cols.txt"]
 outputs = ["Fig12_Split_Corr.png", "coherence_data.json", "coherence.html"]
 
 [container]
-image = "chiral.sakuracr.jp/proteomics:2025_12_31"
+image = "ghcr.io/chiral-data/proteomics:2025_12_31"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-008/README.md
+++ b/workflows/workflow-008/README.md
@@ -480,7 +480,7 @@ The `silva` command discovers all `job.toml` files, resolves dependencies, and e
 1. Reads `.chiral/workflow.toml` in the root directory for workflow-level configuration and dependencies
 2. Scans each node's `.chiral/job.toml` for inputs, outputs, and container settings
 3. Builds a dependency graph based on the `[dependencies]` section in `workflow.toml`
-4. Pulls or reuses the Docker image (`chiral.sakuracr.jp/proteomics:2025_12_31`)
+4. Pulls or reuses the Docker image (`ghcr.io/chiral-data/proteomics:2025_12_31`)
 5. Executes each node's `run.sh` script inside the container
 6. Copies input files between nodes as specified in `job.toml`
 7. Collects outputs to a timestamped folder (e.g., `C:\Windows\TEMP\silva-2026-01-03-...`)
@@ -539,7 +539,7 @@ The database file should be present in Node 01 directory:
 01_Data_Ingestion_and_Preprocessing/database-multiple-sclerosis-myasthenia.csv
 ```
 
-**Note:** Python packages are pre-installed in the Docker image (`chiral.sakuracr.jp/proteomics:2025_12_31`). No local Python environment setup is required.
+**Note:** Python packages are pre-installed in the Docker image (`ghcr.io/chiral-data/proteomics:2025_12_31`). No local Python environment setup is required.
 
 ### Execution Commands
 
@@ -553,7 +553,7 @@ This command executes all 11 nodes with proper dependency ordering. Outputs are 
 ```bash
 # Navigate to node directory and run the script directly
 cd 03_MS_Pathology_Overview
-docker run -v $(pwd):/workspace chiral.sakuracr.jp/proteomics:2025_12_31 bash run.sh
+docker run -v $(pwd):/workspace ghcr.io/chiral-data/proteomics:2025_12_31 bash run.sh
 ```
 
 ### Output Summary

--- a/workflows/workflow-009/01-ligand-upload/.chiral/job.toml
+++ b/workflows/workflow-009/01-ligand-upload/.chiral/job.toml
@@ -3,7 +3,7 @@ description = "Upload and validate the ligand SDF file"
 outputs = ["*.smi", "*.sdf", "ligand_viz.html"]
 
 [container]
-image = "chiral.sakuracr.jp/fegrow:2026_01_10_v4"
+image = "ghcr.io/chiral-data/fegrow:2026_01_10_v4"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-009/02-scaffold-creation/.chiral/job.toml
+++ b/workflows/workflow-009/02-scaffold-creation/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*.smi", "*.sdf"]
 outputs = ["scaffold.pkl", "scaffold_viz.html", "*.smi"]
 
 [container]
-image = "chiral.sakuracr.jp/fegrow:2026_01_10_v4"
+image = "ghcr.io/chiral-data/fegrow:2026_01_10_v4"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-009/03-protein-upload/.chiral/job.toml
+++ b/workflows/workflow-009/03-protein-upload/.chiral/job.toml
@@ -3,7 +3,7 @@ description = "Upload and validate the protein PDB file"
 outputs = ["*.pdb"]
 
 [container]
-image = "chiral.sakuracr.jp/fegrow:2026_01_10_v4"
+image = "ghcr.io/chiral-data/fegrow:2026_01_10_v4"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-009/04-protein-preparation/.chiral/job.toml
+++ b/workflows/workflow-009/04-protein-preparation/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*.pdb"]
 outputs = ["rec_final.pdb"]
 
 [container]
-image = "chiral.sakuracr.jp/fegrow:2026_01_10_v4"
+image = "ghcr.io/chiral-data/fegrow:2026_01_10_v4"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-009/05-chemical-space/.chiral/job.toml
+++ b/workflows/workflow-009/05-chemical-space/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["scaffold.pkl", "rec_final.pdb", "*.smi"]
 outputs = ["chemspace.pkl", "rec_final.pdb", "chemspace_viz.html"]
 
 [container]
-image = "chiral.sakuracr.jp/fegrow:2026_01_10_v4"
+image = "ghcr.io/chiral-data/fegrow:2026_01_10_v4"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-009/06-active-learning-docking/.chiral/job.toml
+++ b/workflows/workflow-009/06-active-learning-docking/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["chemspace.pkl", "rec_final.pdb"]
 outputs = ["chemspace_evaluated.sdf", "iteration_*.csv"]
 
 [container]
-image = "chiral.sakuracr.jp/fegrow:2026_01_10_v4"
+image = "ghcr.io/chiral-data/fegrow:2026_01_10_v4"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-009/07-report/.chiral/job.toml
+++ b/workflows/workflow-009/07-report/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["chemspace_evaluated.sdf"]
 outputs = ["top_compounds.sdf", "top_compounds_report.csv", "summary.txt", "report_viz.html"]
 
 [container]
-image = "chiral.sakuracr.jp/fegrow:2026_01_10_v4"
+image = "ghcr.io/chiral-data/fegrow:2026_01_10_v4"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-011/1_data_prep/.chiral/job.toml
+++ b/workflows/workflow-011/1_data_prep/.chiral/job.toml
@@ -3,7 +3,7 @@ description = "Ingest raw SMILES data and compute descriptors"
 outputs = ["outputs/processed_data.pkl", "outputs/data.json", "outputs/report.html"]
 
 [container]
-image = "chiral.sakuracr.jp/qsar-hybrid-model:v3"
+image = "ghcr.io/chiral-data/qsar-hybrid-model:v3"
 use_gpu = true
 
 [scripts]

--- a/workflows/workflow-011/2_model_train/.chiral/job.toml
+++ b/workflows/workflow-011/2_model_train/.chiral/job.toml
@@ -5,7 +5,7 @@ inputs = ["processed_data.pkl"]
 outputs = ["outputs/hybrid_model.keras", "outputs/training_history.pkl", "outputs/hybrid_ultimate_pipeline.pkl", "outputs/data.json", "outputs/report.html"]
 
 [container]
-image = "chiral.sakuracr.jp/qsar-hybrid-model:v3"
+image = "ghcr.io/chiral-data/qsar-hybrid-model:v3"
 use_gpu = true
 
 [scripts]

--- a/workflows/workflow-011/3_analyze_overfitting/.chiral/job.toml
+++ b/workflows/workflow-011/3_analyze_overfitting/.chiral/job.toml
@@ -5,7 +5,7 @@ inputs = ["processed_data.pkl", "hybrid_model.keras", "training_history.pkl"]
 outputs = ["outputs/data.json", "outputs/report.html"]
 
 [container]
-image = "chiral.sakuracr.jp/qsar-hybrid-model:v3"
+image = "ghcr.io/chiral-data/qsar-hybrid-model:v3"
 use_gpu = true
 
 [scripts]

--- a/workflows/workflow-011/4_predict_from_csv/.chiral/job.toml
+++ b/workflows/workflow-011/4_predict_from_csv/.chiral/job.toml
@@ -5,7 +5,7 @@ inputs = ["hybrid_model.keras", "hybrid_ultimate_pipeline.pkl"]
 outputs = ["outputs/data.json", "outputs/report.html", "outputs/predictions.csv"]
 
 [container]
-image = "chiral.sakuracr.jp/qsar-hybrid-model:v3"
+image = "ghcr.io/chiral-data/qsar-hybrid-model:v3"
 use_gpu = true
 
 [scripts]

--- a/workflows/workflow-012/01-sequence-upload/.chiral/job.toml
+++ b/workflows/workflow-012/01-sequence-upload/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*.yaml"]
 outputs = ["*.yaml", "input_summary.json"]
 
 [container]
-image = "chiral.sakuracr.jp/boltz:2025_09_05"
+image = "ghcr.io/chiral-data/boltz:2025_09_05"
 use_gpu = true
 
 [scripts]

--- a/workflows/workflow-012/02-structure-prediction/.chiral/job.toml
+++ b/workflows/workflow-012/02-structure-prediction/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*.yaml"]
 outputs = ["*_model_*.pdb", "confidence_*.json", "pae_*.npz", "pde_*.npz", "plddt_*.npz"]
 
 [container]
-image = "chiral.sakuracr.jp/boltz:2025_09_05"
+image = "ghcr.io/chiral-data/boltz:2025_09_05"
 use_gpu = true
 
 [scripts]

--- a/workflows/workflow-012/03-report/.chiral/job.toml
+++ b/workflows/workflow-012/03-report/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*_model_*.pdb", "confidence_*.json", "pae_*.npz", "pde_*.npz", "plddt
 outputs = ["boltz_dashboard_*.html"]
 
 [container]
-image = "chiral.sakuracr.jp/boltz_report:2026_02_13"
+image = "ghcr.io/chiral-data/boltz_report:2026_02_13"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-012/README.md
+++ b/workflows/workflow-012/README.md
@@ -45,8 +45,8 @@ sequences:
 
 | Node | Image |
 |------|-------|
-| 01, 02 | `chiral.sakuracr.jp/boltz:2025_09_05` |
-| 03 | `chiral.sakuracr.jp/boltz_report:2026_02_13` |
+| 01, 02 | `ghcr.io/chiral-data/boltz:2025_09_05` |
+| 03 | `ghcr.io/chiral-data/boltz_report:2026_02_13` |
 
 ## Example
 

--- a/workflows/workflow-013/01-target-upload/.chiral/job.toml
+++ b/workflows/workflow-013/01-target-upload/.chiral/job.toml
@@ -3,7 +3,7 @@ description = "Upload and validate target structure and design specification for
 outputs = ["*.yaml", "*.cif", "*.pdb", "target_summary.json"]
 
 [container]
-image = "chiral.sakuracr.jp/boltzgen:2026_02_13"
+image = "ghcr.io/chiral-data/boltzgen:2026_02_13"
 use_gpu = true
 
 [scripts]

--- a/workflows/workflow-013/02-binder-design/.chiral/job.toml
+++ b/workflows/workflow-013/02-binder-design/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["design_spec.yaml", "*.cif", "*.pdb"]
 outputs = ["*.cif", "aggregate_metrics_analyze.csv", "results_overview.pdf"]
 
 [container]
-image = "chiral.sakuracr.jp/boltzgen:2026_02_13"
+image = "ghcr.io/chiral-data/boltzgen:2026_02_13"
 use_gpu = true
 
 [scripts]

--- a/workflows/workflow-013/03-report/.chiral/job.toml
+++ b/workflows/workflow-013/03-report/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*.cif", "aggregate_metrics_analyze.csv"]
 outputs = ["boltzgen_dashboard_*.html"]
 
 [container]
-image = "chiral.sakuracr.jp/boltz_report:2026_02_13"
+image = "ghcr.io/chiral-data/boltz_report:2026_02_13"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-013/README.md
+++ b/workflows/workflow-013/README.md
@@ -72,5 +72,5 @@ sequences:
 
 | Node | Image |
 |------|-------|
-| 01, 02, 04 | `chiral.sakuracr.jp/boltzgen:2026_02_13` |
-| 03 | `chiral.sakuracr.jp/boltz_report:2026_02_13` |
+| 01, 02, 04 | `ghcr.io/chiral-data/boltzgen:2026_02_13` |
+| 03 | `ghcr.io/chiral-data/boltz_report:2026_02_13` |


### PR DESCRIPTION
Closes #92

## Summary

- Replace all `chiral.sakuracr.jp` references with `ghcr.io/chiral-data`
- Updates `apps/build.sh`, `apps/applications.json`, `apps/README.md`, all `job.toml` files across workflows, workflow READMEs, and `start_server.ps1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)