### PR TITLE
docs: add workflow-015 (mDeepFRI) and 017 (Priyam WIP) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ A collection of scientific computing workflows for drug discovery, molecular ana
 12. [Boltz-2](https://github.com/jwohlwend/boltz) Structure Prediction by Chiral Dev Team
 13. [BoltzGen](https://github.com/HannesStark/boltzgen) Binder Design by Chiral Dev Team
 14. [ADMET-AI](https://github.com/swansonk14/admet_ai) Prediction Pipeline by [Allison Cheng](https://github.com/allisongcheng)
-15. Boltz-2 vs Chai-1 Structure Comparison by [Priyam Baruah](https://github.com/PriyamBaruah1199)
+15. [mDeepFRI Protein Function Prediction](workflows/workflow-015/README.md) based on [Metagenomic-DeepFRI](https://github.com/bioinf-mcb/Metagenomic-DeepFRI) by [Allison Cheng](https://github.com/allisongcheng)
 16. [DiffDock-PP Antibody-Antigen Docking Pipeline](workflows/workflow-016/README.md) by [Abdelrahman Mohamed Taha MAHMOUD](https://www.linkedin.com/in/abdelrahman-mohamed-taha-mahmoud/)
+17. Boltz-2 vs Chai-1 Structure Comparison by [Priyam Baruah](https://github.com/PriyamBaruah1199) :construction:


### PR DESCRIPTION
## Summary
- Insert workflow-015 (mDeepFRI Protein Function Prediction by @allisongcheng) at entry 15 in the README, with links to the workflow source and the upstream [Metagenomic-DeepFRI](https://github.com/bioinf-mcb/Metagenomic-DeepFRI) tool
- Shift Priyam's Boltz-2 vs Chai-1 entry from position 15 to 17 (marked WIP) now that 15 is taken by mDeepFRI

🤖 Generated with [Claude Code](https://claude.com/claude-code)