### PR TITLE
feat: add CI/CD to build Docker images for workflow job folders

### DIFF
--- a/.github/workflows/build-changed-workflow-images.yml
+++ b/.github/workflows/build-changed-workflow-images.yml
@@ -14,7 +14,8 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.changed.outputs.matrix }}
+      independent: ${{ steps.changed.outputs.independent }}
+      dependent: ${{ steps.changed.outputs.dependent }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,7 +25,14 @@ jobs:
       - name: Detect changed job directories
         id: changed
         run: |
-          DIRS=$(git diff --name-only HEAD~1 HEAD \
+          ALL_JOB_IMAGES=$(find workflows -name "job.toml" | while read f; do
+            job_dir=$(dirname "$(dirname "$f")")
+            if [ -f "$job_dir/Dockerfile" ]; then
+              grep -A20 '\[container\]' "$f" | grep '^image' | head -1 | sed 's/image = "\(.*\)"/\1/' | cut -d: -f1
+            fi
+          done | sort -u)
+
+          CHANGED=$(git diff --name-only HEAD~1 HEAD \
             | grep '^workflows/' \
             | awk -F'/' 'NF>=4 {print $2"/"$3}' \
             | sort -u \
@@ -32,21 +40,99 @@ jobs:
                 if [ -f "workflows/$dir/Dockerfile" ] && [ -f "workflows/$dir/.chiral/job.toml" ]; then
                   echo "$dir"
                 fi
-              done \
-            | jq -R . | jq -sc .)
-          echo "matrix=$DIRS" >> $GITHUB_OUTPUT
-          echo "Changed: $DIRS"
+              done)
 
-  build:
+          INDEPENDENT=""
+          DEPENDENT=""
+          while IFS= read -r dir; do
+            [ -z "$dir" ] && continue
+            FROM_NAME=$(grep '^FROM' "workflows/$dir/Dockerfile" | head -1 | awk '{print $2}' | cut -d: -f1)
+            if echo "$ALL_JOB_IMAGES" | grep -qx "$FROM_NAME"; then
+              DEPENDENT="$DEPENDENT$dir\n"
+            else
+              INDEPENDENT="$INDEPENDENT$dir\n"
+            fi
+          done <<< "$CHANGED"
+
+          IND=$(printf "$INDEPENDENT" | grep -v '^$' | jq -R . | jq -sc .)
+          DEP=$(printf "$DEPENDENT" | grep -v '^$' | jq -R . | jq -sc .)
+          echo "independent=$IND" >> $GITHUB_OUTPUT
+          echo "dependent=$DEP" >> $GITHUB_OUTPUT
+          echo "Independent: $IND"
+          echo "Dependent: $DEP"
+
+  build-independent:
     needs: detect
-    if: ${{ needs.detect.outputs.matrix != '[]' && needs.detect.outputs.matrix != '' }}
+    if: ${{ needs.detect.outputs.independent != '[]' && needs.detect.outputs.independent != '' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     strategy:
       matrix:
-        job_dir: ${{ fromJson(needs.detect.outputs.matrix) }}
+        job_dir: ${{ fromJson(needs.detect.outputs.independent) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read image name from job.toml
+        id: meta
+        run: |
+          TOML="workflows/${{ matrix.job_dir }}/.chiral/job.toml"
+          RAW=$(grep -A20 '\[container\]' "$TOML" | grep '^image' | head -1 | sed 's/image = "\(.*\)"/\1/')
+          IMAGE_NAME=$(echo "$RAW" | cut -d: -f1)
+          IMAGE_TAG=$(echo "$RAW" | cut -d: -f2)
+          echo "image=${{ env.REGISTRY }}/${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "image_name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull and retag local base images
+        run: |
+          FROM_IMAGE=$(grep '^FROM' workflows/${{ matrix.job_dir }}/Dockerfile | head -1 | awk '{print $2}')
+          if [[ "$FROM_IMAGE" != *"/"* ]]; then
+            REGISTRY_IMAGE="${{ env.REGISTRY }}/${FROM_IMAGE}"
+            if docker pull "$REGISTRY_IMAGE" 2>/dev/null; then
+              docker tag "$REGISTRY_IMAGE" "$FROM_IMAGE"
+            fi
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: workflows/${{ matrix.job_dir }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+
+      - name: Make package public
+        continue-on-error: true
+        run: |
+          gh api --method PATCH \
+            /orgs/chiral-data/packages/container/${{ steps.meta.outputs.image_name }} \
+            -f visibility=public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-dependent:
+    needs: [detect, build-independent]
+    if: |
+      always() &&
+      needs.detect.outputs.dependent != '[]' && needs.detect.outputs.dependent != '' &&
+      (needs.build-independent.result == 'success' || needs.build-independent.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        job_dir: ${{ fromJson(needs.detect.outputs.dependent) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-changed-workflow-images.yml
+++ b/.github/workflows/build-changed-workflow-images.yml
@@ -69,6 +69,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Pull and retag local base images
+        run: |
+          FROM_IMAGE=$(grep '^FROM' workflows/${{ matrix.job_dir }}/Dockerfile | head -1 | awk '{print $2}')
+          if [[ "$FROM_IMAGE" != *"/"* ]]; then
+            REGISTRY_IMAGE="${{ env.REGISTRY }}/${FROM_IMAGE}"
+            if docker pull "$REGISTRY_IMAGE" 2>/dev/null; then
+              docker tag "$REGISTRY_IMAGE" "$FROM_IMAGE"
+            fi
+          fi
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/build-changed-workflow-images.yml
+++ b/.github/workflows/build-changed-workflow-images.yml
@@ -1,0 +1,87 @@
+name: Build and Push Changed Workflow Job Images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "workflows/*/*/**"
+
+env:
+  REGISTRY: ghcr.io/chiral-data
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.changed.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect changed job directories
+        id: changed
+        run: |
+          DIRS=$(git diff --name-only HEAD~1 HEAD \
+            | grep '^workflows/' \
+            | awk -F'/' 'NF>=4 {print $2"/"$3}' \
+            | sort -u \
+            | while read dir; do
+                if [ -f "workflows/$dir/Dockerfile" ] && [ -f "workflows/$dir/.chiral/job.toml" ]; then
+                  echo "$dir"
+                fi
+              done \
+            | jq -R . | jq -sc .)
+          echo "matrix=$DIRS" >> $GITHUB_OUTPUT
+          echo "Changed: $DIRS"
+
+  build:
+    needs: detect
+    if: ${{ needs.detect.outputs.matrix != '[]' && needs.detect.outputs.matrix != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        job_dir: ${{ fromJson(needs.detect.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read image name from job.toml
+        id: meta
+        run: |
+          TOML="workflows/${{ matrix.job_dir }}/.chiral/job.toml"
+          RAW=$(grep -A20 '\[container\]' "$TOML" | grep '^image' | head -1 | sed 's/image = "\(.*\)"/\1/')
+          IMAGE_NAME=$(echo "$RAW" | cut -d: -f1)
+          IMAGE_TAG=$(echo "$RAW" | cut -d: -f2)
+          echo "image=${{ env.REGISTRY }}/${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "image_name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: workflows/${{ matrix.job_dir }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+
+      - name: Make package public
+        continue-on-error: true
+        run: |
+          gh api --method PATCH \
+            /orgs/chiral-data/packages/container/${{ steps.meta.outputs.image_name }} \
+            -f visibility=public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-workflow-image.yml
+++ b/.github/workflows/build-workflow-image.yml
@@ -1,0 +1,79 @@
+name: Build and Push Workflow Job Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      job_dir:
+        description: "Job directory relative to workflows/ (e.g. workflow-019/01-sequence-ingest)"
+        required: true
+        type: string
+      force_rebuild:
+        description: "Force rebuild even if image already exists"
+        required: false
+        default: false
+        type: boolean
+
+env:
+  REGISTRY: ghcr.io/chiral-data
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read image name from job.toml
+        id: meta
+        run: |
+          TOML="workflows/${{ inputs.job_dir }}/.chiral/job.toml"
+          RAW=$(grep -A20 '\[container\]' "$TOML" | grep '^image' | head -1 | sed 's/image = "\(.*\)"/\1/')
+          IMAGE_NAME=$(echo "$RAW" | cut -d: -f1)
+          IMAGE_TAG=$(echo "$RAW" | cut -d: -f2)
+          echo "image=${{ env.REGISTRY }}/${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "image_name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Check if image already exists
+        id: check
+        if: ${{ !inputs.force_rebuild }}
+        run: |
+          if docker manifest inspect ${{ steps.meta.outputs.image }} > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Log in to ghcr.io
+        if: ${{ inputs.force_rebuild || steps.check.outputs.exists != 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        if: ${{ inputs.force_rebuild || steps.check.outputs.exists != 'true' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: workflows/${{ inputs.job_dir }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+
+      - name: Make package public
+        if: ${{ inputs.force_rebuild || steps.check.outputs.exists != 'true' }}
+        continue-on-error: true
+        run: |
+          gh api --method PATCH \
+            /orgs/chiral-data/packages/container/${{ steps.meta.outputs.image_name }} \
+            -f visibility=public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Skip (image already exists)
+        if: ${{ !inputs.force_rebuild && steps.check.outputs.exists == 'true' }}
+        run: echo "Image ${{ steps.meta.outputs.image }} already exists, skipping build."

--- a/.github/workflows/build-workflow-image.yml
+++ b/.github/workflows/build-workflow-image.yml
@@ -55,6 +55,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Pull and retag local base images
+        if: ${{ inputs.force_rebuild || steps.check.outputs.exists != 'true' }}
+        run: |
+          FROM_IMAGE=$(grep '^FROM' workflows/${{ inputs.job_dir }}/Dockerfile | head -1 | awk '{print $2}')
+          if [[ "$FROM_IMAGE" != *"/"* ]]; then
+            REGISTRY_IMAGE="${{ env.REGISTRY }}/${FROM_IMAGE}"
+            if docker pull "$REGISTRY_IMAGE" 2>/dev/null; then
+              docker tag "$REGISTRY_IMAGE" "$FROM_IMAGE"
+            fi
+          fi
+
       - name: Build and push
         if: ${{ inputs.force_rebuild || steps.check.outputs.exists != 'true' }}
         uses: docker/build-push-action@v6

--- a/apps/README.md
+++ b/apps/README.md
@@ -25,3 +25,45 @@ docker pull ghcr.io/chiral-data/gromacs:2025_09_05
 1. create a new directory as `./a/app_date`. For test builds, append a version suffix, such as `_v1` (e.g., `app_date_v1`).
 2. create the `Dockerfile`
 3. Execute the `build.sh` script from the project's root directory using the command: `bash build.sh ./a/app_date_v1`.
+
+---
+
+# Workflow Job Images
+
+Container images for workflow job folders are hosted at `ghcr.io/chiral-data` alongside app images, but follow a different naming and build convention.
+
+## Image naming
+
+Image names and tags are defined in the job's `.chiral/job.toml`:
+
+```toml
+[container]
+image = "sequence-ingest:latest"
+```
+
+The CI prepends `ghcr.io/chiral-data/` automatically. The `image` field in `job.toml` should always be a bare name without registry prefix.
+
+## Eligibility
+
+A job folder is built only if it contains **both**:
+- `Dockerfile` — the build definition
+- `.chiral/job.toml` — with a `[container].image` field
+
+## How to build a new workflow job image
+
+### Automatic (on push to `main`)
+
+Any push to `main` that touches `workflows/*/*/**` triggers `build-changed-workflow-images.yml`, which detects changed eligible job folders and builds them automatically.
+
+### Manual
+
+Trigger `build-workflow-image.yml` via GitHub Actions → Run workflow:
+
+| Field | Description | Example |
+|---|---|---|
+| `job_dir` | Path relative to `workflows/` | `workflow-019/01-sequence-ingest` |
+| `force_rebuild` | Rebuild even if image exists | `false` |
+
+## Build order
+
+If a job's `Dockerfile` uses `FROM <bare-name>` where `<bare-name>` matches another job's image in this repo, it is treated as a **dependent** job and built only after all independent jobs complete. This ensures e.g. `esmfold:latest` is pushed before any job that builds `FROM esmfold:latest`.


### PR DESCRIPTION
Closes #113

## Summary

- `build-workflow-image.yml` — manual dispatch, takes a `job_dir` (e.g. `workflow-019/01-sequence-ingest`) and optional `force_rebuild`
- `build-changed-workflow-images.yml` — auto on push to `main`, detects changed job folders with both `Dockerfile` and `.chiral/job.toml`

Both workflows read the image name from `[container].image` in `.chiral/job.toml` and push to `ghcr.io/chiral-data/`.

## Key design decisions

- Only builds job folders that have **both** a `Dockerfile` and a `.chiral/job.toml`
- Bare `FROM` base images (no `/`) are pulled from `ghcr.io/chiral-data/` and retagged locally before build, so Dockerfiles like `FROM esmfold:latest` resolve without modification
- Build order: auto-detects internal base image dependencies and runs dependent jobs (`05-structure-scoring-generated`) only after independent jobs (`02-structure-prediction`) complete