### PR TITLE
ci: add workflow to build shared workflow-level Dockerfiles

### DIFF
--- a/.github/workflows/build-changed-shared-workflow-images.yml
+++ b/.github/workflows/build-changed-shared-workflow-images.yml
@@ -6,6 +6,11 @@ on:
       - main
     paths:
       - "workflows/*/*/**"
+  workflow_dispatch:
+    inputs:
+      workflow_dirs:
+        description: "Space-separated list of workflow dirs to build (e.g. workflow-014 workflow-015)"
+        required: true
 
 env:
   REGISTRY: ghcr.io/chiral-data
@@ -25,20 +30,25 @@ jobs:
       - name: Detect changed job directories using shared workflow Dockerfile
         id: changed
         run: |
-          DIRS=$(git diff --name-only HEAD~1 HEAD \
-            | grep '^workflows/' \
-            | awk -F'/' 'NF>=4 {print $2"/"$3}' \
-            | sort -u \
-            | while read dir; do
-                workflow=$(echo "$dir" | cut -d'/' -f1)
-                if [ -f "workflows/$dir/.chiral/job.toml" ] \
-                    && [ ! -f "workflows/$dir/Dockerfile" ] \
-                    && [ -f "workflows/$workflow/Dockerfile" ]; then
-                  echo "$workflow"
-                fi
-              done \
-            | sort -u \
-            | jq -R . | jq -sc .)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            DIRS=$(echo "${{ github.event.inputs.workflow_dirs }}" \
+              | tr ' ' '\n' | jq -R . | jq -sc .)
+          else
+            DIRS=$(git diff --name-only HEAD~1 HEAD \
+              | grep '^workflows/' \
+              | awk -F'/' 'NF>=4 {print $2"/"$3}' \
+              | sort -u \
+              | while read dir; do
+                  workflow=$(echo "$dir" | cut -d'/' -f1)
+                  if [ -f "workflows/$dir/.chiral/job.toml" ] \
+                      && [ ! -f "workflows/$dir/Dockerfile" ] \
+                      && [ -f "workflows/$workflow/Dockerfile" ]; then
+                    echo "$workflow"
+                  fi
+                done \
+              | sort -u \
+              | jq -R . | jq -sc .)
+          fi
           echo "matrix=$DIRS" >> $GITHUB_OUTPUT
           echo "Changed: $DIRS"
 

--- a/.github/workflows/build-changed-shared-workflow-images.yml
+++ b/.github/workflows/build-changed-shared-workflow-images.yml
@@ -1,0 +1,94 @@
+name: Build and Push Changed Shared Workflow Images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "workflows/*/*/**"
+
+env:
+  REGISTRY: ghcr.io/chiral-data
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.changed.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          submodules: true
+
+      - name: Detect changed job directories using shared workflow Dockerfile
+        id: changed
+        run: |
+          DIRS=$(git diff --name-only HEAD~1 HEAD \
+            | grep '^workflows/' \
+            | awk -F'/' 'NF>=4 {print $2"/"$3}' \
+            | sort -u \
+            | while read dir; do
+                workflow=$(echo "$dir" | cut -d'/' -f1)
+                if [ -f "workflows/$dir/.chiral/job.toml" ] \
+                    && [ ! -f "workflows/$dir/Dockerfile" ] \
+                    && [ -f "workflows/$workflow/Dockerfile" ]; then
+                  echo "$workflow"
+                fi
+              done \
+            | sort -u \
+            | jq -R . | jq -sc .)
+          echo "matrix=$DIRS" >> $GITHUB_OUTPUT
+          echo "Changed: $DIRS"
+
+  build:
+    needs: detect
+    if: ${{ needs.detect.outputs.matrix != '[]' && needs.detect.outputs.matrix != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        workflow_dir: ${{ fromJson(needs.detect.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Read image name from job.toml
+        id: meta
+        run: |
+          TOML=$(find "workflows/${{ matrix.workflow_dir }}" -name "job.toml" | sort | head -1)
+          RAW=$(grep -A20 '\[container\]' "$TOML" | grep '^image' | head -1 | sed 's/image = "\(.*\)"/\1/')
+          IMAGE_NAME=$(echo "$RAW" | cut -d: -f1)
+          IMAGE_TAG=$(echo "$RAW" | cut -d: -f2)
+          echo "image=${{ env.REGISTRY }}/${IMAGE_NAME}:${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "image_name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: workflows/${{ matrix.workflow_dir }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.image }}
+
+      - name: Make package public
+        continue-on-error: true
+        run: |
+          gh api --method PATCH \
+            /orgs/chiral-data/packages/container/${{ steps.meta.outputs.image_name }} \
+            -f visibility=public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `build-changed-shared-workflow-images.yml` to handle workflows with a shared Dockerfile at the workflow level (e.g. `workflow-014`)
- Detection logic: for each changed job directory, checks if the job has its own `Dockerfile`; if not, falls back to the workflow-level `Dockerfile`
- Deduplicates by workflow dir so the shared image is built once even if multiple jobs changed
- Image name/tag read from the first `job.toml` found in the workflow dir

Closes #115