### PR TITLE
fix: workflow-015 validate_inputs accept only *.fasta

### DIFF
--- a/workflows/workflow-015/01_validate_inputs/.chiral/job.toml
+++ b/workflows/workflow-015/01_validate_inputs/.chiral/job.toml
@@ -1,7 +1,7 @@
 name = "Validate Inputs"
 description = "Validates FASTA format, confirms protein sequences, and filters by length"
 
-inputs = ["*.fasta"]
+inputs = ["*.{fasta,fa,faa}"]
 outputs = ["validated.fasta", "validation_report.json"]
 
 [container]

--- a/workflows/workflow-015/01_validate_inputs/.chiral/job.toml
+++ b/workflows/workflow-015/01_validate_inputs/.chiral/job.toml
@@ -1,7 +1,7 @@
 name = "Validate Inputs"
 description = "Validates FASTA format, confirms protein sequences, and filters by length"
 
-inputs = ["*.fasta", "*.fa", "*.faa"]
+inputs = ["*.fasta"]
 outputs = ["validated.fasta", "validation_report.json"]
 
 [container]


### PR DESCRIPTION
## Summary

- Closes #117
- Changed `inputs` in `01_validate_inputs/job.toml` from three patterns (`*.fasta`, `*.fa`, `*.faa`) to only `*.fasta`
- Backend was treating multiple patterns as all-required instead of any-one-of

## Test plan

- [x] Run workflow-015 with a single `.fasta` file and confirm the validate_inputs job accepts it without errors