### PR TITLE
Add workflow-021: MVRBind RNA binding site prediction (submodule)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "workflows/workflow-019"]
 	path = workflows/workflow-019
 	url = https://github.com/SauravKulkarni3999/cyclic-amp-design-pipeline.git
+[submodule "workflows/workflow-021"]
+	path = workflows/workflow-021
+	url = https://github.com/rogerwq/mvrbind-workflow.git

--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ A collection of scientific computing workflows for drug discovery, molecular ana
 17. [LightDock Protein-Protein Docking](workflows/workflow-017/README.md) based on [LightDock](https://github.com/lightdock/lightdock) by [Allison Cheng](https://github.com/allisongcheng)
 18. [Boltz-2 vs Chai-1 Structure Comparison](workflows/workflow-018/README.md) based on [Boltz-2](https://github.com/jwohlwend/boltz) and [Chai-1](https://github.com/chaidiscovery/chai-lab) by [Priyam Baruah](https://github.com/PriyamBaruah1199)
 19. [Cyclic AMP Antimicrobial Peptide Design Pipeline](https://github.com/SauravKulkarni3999/cyclic-amp-design-pipeline) — DPO-aligned generative design with biophysics scoring and physics validation by [Saurav Kulkarni](https://www.linkedin.com/in/sauravkulkarni/)
+20. :checkered_flag:
+21. [MVRBind RNA Binding Site Prediction](https://github.com/rogerwq/mvrbind-workflow) — per-nucleotide RNA-small molecule binding site prediction using multi-view GCN by Chiral Dev Team


### PR DESCRIPTION
Closes #122

## Changes

- Added `workflows/workflow-021` as a git submodule pointing to [rogerwq/mvrbind-workflow](https://github.com/rogerwq/mvrbind-workflow)

## Verified

All 3 nodes pass via `silva workflows/workflow-021` headless run.

## References

- MVRBind app PR: #120
- Workflow repo PR: [rogerwq/mvrbind-workflow#2](https://github.com/rogerwq/mvrbind-workflow/pull/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)