### PR TITLE
Fix MVRBind app: add missing pandas dependency

### DIFF
--- a/apps/m/mvrbind_2026_05_14/Dockerfile
+++ b/apps/m/mvrbind_2026_05_14/Dockerfile
@@ -43,7 +43,8 @@ RUN pip install --no-cache-dir \
     scipy==1.15.3 \
     matplotlib==3.10.3 \
     tqdm==4.67.1 \
-    pyyaml==6.0.2
+    pyyaml==6.0.2 \
+    pandas==2.2.3
 
 # Clone MVRBind (includes bundled ClustalW binary)
 WORKDIR /opt


### PR DESCRIPTION
Closes #121

## Changes

- Added `pandas==2.2.3` to pip install step in `apps/m/mvrbind_2026_05_14/Dockerfile`

## Verified

Image rebuilt locally. MVRBind workflow (`workflow-021`) passes all 3 silva nodes after this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)