### PR TITLE
Add RiNALMo app — 650M-param RNA language model

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "workflows/workflow-021"]
 	path = workflows/workflow-021
 	url = https://github.com/rogerwq/mvrbind-workflow.git
+[submodule "workflows/workflow-022"]
+	path = workflows/workflow-022
+	url = https://github.com/rogerwq/rinalmo-workflow.git

--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ A collection of scientific computing workflows for drug discovery, molecular ana
 19. [Cyclic AMP Antimicrobial Peptide Design Pipeline](https://github.com/SauravKulkarni3999/cyclic-amp-design-pipeline) — DPO-aligned generative design with biophysics scoring and physics validation by [Saurav Kulkarni](https://www.linkedin.com/in/sauravkulkarni/)
 20. :checkered_flag:
 21. [MVRBind RNA Binding Site Prediction](https://github.com/rogerwq/mvrbind-workflow) — per-nucleotide RNA-small molecule binding site prediction using multi-view GCN by Chiral Dev Team
+22. [RiNALMo RNA Secondary Structure Prediction](https://github.com/rogerwq/rinalmo-workflow) — secondary structure prediction using the 650M-param RiNALMo language model (bpRNA fine-tuned) by Chiral Dev Team

--- a/apps/applications.json
+++ b/apps/applications.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "last_updated": "2026-02-13",
+  "last_updated": "2026-05-14",
   "applications": [
     {
       "id": "boltz",
@@ -12,7 +12,12 @@
       "base_image": "nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04",
       "registry": "ghcr.io/chiral-data",
       "image_path": "/boltz:2025_09_05",
-      "tags": ["protein", "ml", "gpu", "structure-prediction"],
+      "tags": [
+        "protein",
+        "ml",
+        "gpu",
+        "structure-prediction"
+      ],
       "requirements": {
         "gpu": true,
         "memory_gb": 8,
@@ -30,7 +35,12 @@
       "base_image": "nvcr.io/hpc/gromacs:2023.2",
       "registry": "ghcr.io/chiral-data",
       "image_path": "/gromacs:2025_09_05",
-      "tags": ["simulation", "molecular-dynamics", "hpc", "gpu"],
+      "tags": [
+        "simulation",
+        "molecular-dynamics",
+        "hpc",
+        "gpu"
+      ],
       "requirements": {
         "gpu": true,
         "memory_gb": 4,
@@ -48,7 +58,11 @@
       "base_image": "ubuntu:22.04",
       "registry": "ghcr.io/chiral-data",
       "image_path": "/blast:2025_10_14",
-      "tags": ["alignment", "sequence", "bioinformatics"],
+      "tags": [
+        "alignment",
+        "sequence",
+        "bioinformatics"
+      ],
       "requirements": {
         "gpu": false,
         "memory_gb": 2,
@@ -66,7 +80,12 @@
       "base_image": "nvidia/cuda:11.8.0-runtime-ubuntu22.04",
       "registry": "ghcr.io/chiral-data",
       "image_path": "/proteinmpnn:2025_09_10",
-      "tags": ["protein", "design", "ml", "gpu"],
+      "tags": [
+        "protein",
+        "design",
+        "ml",
+        "gpu"
+      ],
       "requirements": {
         "gpu": true,
         "memory_gb": 6,
@@ -84,7 +103,12 @@
       "base_image": "nvidia/cuda:12.0.0-runtime-ubuntu22.04",
       "registry": "ghcr.io/chiral-data",
       "image_path": "/rfdiffusion2:2025_09_19",
-      "tags": ["protein", "diffusion", "generation", "gpu"],
+      "tags": [
+        "protein",
+        "diffusion",
+        "generation",
+        "gpu"
+      ],
       "requirements": {
         "gpu": true,
         "memory_gb": 10,
@@ -102,7 +126,12 @@
       "base_image": "nvidia/cuda:11.3.0-runtime-ubuntu20.04",
       "registry": "ghcr.io/chiral-data",
       "image_path": "/ufold:2025_09_18",
-      "tags": ["rna", "structure", "ml", "gpu"],
+      "tags": [
+        "rna",
+        "structure",
+        "ml",
+        "gpu"
+      ],
       "requirements": {
         "gpu": true,
         "memory_gb": 4,
@@ -120,7 +149,11 @@
       "base_image": "ubuntu:22.04",
       "registry": "ghcr.io/chiral-data",
       "image_path": "/intarna:2025_09_18",
-      "tags": ["rna", "interaction", "prediction"],
+      "tags": [
+        "rna",
+        "interaction",
+        "prediction"
+      ],
       "requirements": {
         "gpu": false,
         "memory_gb": 2,
@@ -138,7 +171,13 @@
       "base_image": "nvidia/cuda:11.6.0-runtime-ubuntu20.04",
       "registry": "ghcr.io/chiral-data",
       "image_path": "/rnamigos2:2025_09_19",
-      "tags": ["rna", "ligand", "ml", "gpu", "drug-discovery"],
+      "tags": [
+        "rna",
+        "ligand",
+        "ml",
+        "gpu",
+        "drug-discovery"
+      ],
       "requirements": {
         "gpu": true,
         "memory_gb": 5,
@@ -156,7 +195,12 @@
       "base_image": "nvidia/cuda:11.8.0-runtime-ubuntu22.04",
       "registry": "ghcr.io/chiral-data",
       "image_path": "/freebindcraft:2025_09_19",
-      "tags": ["protein", "ligand", "free-energy", "gpu"],
+      "tags": [
+        "protein",
+        "ligand",
+        "free-energy",
+        "gpu"
+      ],
       "requirements": {
         "gpu": true,
         "memory_gb": 8,
@@ -174,7 +218,11 @@
       "base_image": "ubuntu:22.04",
       "registry": "ghcr.io/chiral-data",
       "image_path": "/rnahybrid:2025_10_14",
-      "tags": ["rna", "mirna", "target-prediction"],
+      "tags": [
+        "rna",
+        "mirna",
+        "target-prediction"
+      ],
       "requirements": {
         "gpu": false,
         "memory_gb": 1,
@@ -192,7 +240,13 @@
       "base_image": "nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04",
       "registry": "ghcr.io/chiral-data",
       "image_path": "/boltzgen:2026_02_13",
-      "tags": ["protein", "design", "binder", "ml", "gpu"],
+      "tags": [
+        "protein",
+        "design",
+        "binder",
+        "ml",
+        "gpu"
+      ],
       "requirements": {
         "gpu": true,
         "memory_gb": 10,
@@ -210,7 +264,14 @@
       "base_image": "nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04",
       "registry": "ghcr.io/chiral-data",
       "image_path": "/mvrbind:2026_05_14",
-      "tags": ["rna", "ligand", "binding-site", "ml", "gpu", "drug-discovery"],
+      "tags": [
+        "rna",
+        "ligand",
+        "binding-site",
+        "ml",
+        "gpu",
+        "drug-discovery"
+      ],
       "requirements": {
         "gpu": true,
         "memory_gb": 6,
@@ -228,13 +289,44 @@
       "base_image": "python:3.8",
       "registry": "ghcr.io/chiral-data",
       "image_path": "/boltz_report:2026_02_13",
-      "tags": ["reporting", "visualization", "dashboard"],
+      "tags": [
+        "reporting",
+        "visualization",
+        "dashboard"
+      ],
       "requirements": {
         "gpu": false,
         "memory_gb": 2,
         "cuda_version": null
       },
       "documentation_url": ""
+    },
+    {
+      "id": "rinalmo",
+      "name": "RiNALMo",
+      "version": "2026_05_14",
+      "category": "RNA-Structure",
+      "description": "General-purpose RNA language model for structure and function prediction",
+      "long_description": "RiNALMo (RiboNucleic Acid Language Model) is a 650M-parameter BERT-style Transformer pre-trained on 36M non-coding RNA sequences. It achieves state-of-the-art performance on secondary structure prediction, splice-site prediction, ncRNA family classification, ribosome loading, translation efficiency, and expression level tasks. The model generalises to RNA families not seen during training. Available in three sizes: Giga (650M), Mega (150M), and Micro (35M).",
+      "base_image": "nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04",
+      "registry": "ghcr.io/chiral-data",
+      "image_path": "/rinalmo:2026_05_14",
+      "tags": [
+        "rna",
+        "language-model",
+        "secondary-structure",
+        "ncRNA",
+        "splice-site",
+        "expression",
+        "ml",
+        "gpu"
+      ],
+      "requirements": {
+        "gpu": true,
+        "memory_gb": 8,
+        "cuda_version": "11.8"
+      },
+      "documentation_url": "https://github.com/lbcb-sci/RiNALMo"
     }
   ]
 }

--- a/apps/r/rinalmo_2026_05_14/Dockerfile
+++ b/apps/r/rinalmo_2026_05_14/Dockerfile
@@ -45,7 +45,8 @@ RUN pip install --no-cache-dir \
     einops==0.7.0 \
     biopython==1.81 \
     pytorch-lightning==2.1.3 \
-    torchmetrics==1.2.1
+    torchmetrics==1.2.1 \
+    scikit-learn==1.3.1
 
 # Bake in fine-tuned weights for secondary structure prediction (bpRNA, ~2.5 GB).
 # The checkpoint includes the full model (LM + head) so no separate base weights needed.

--- a/apps/r/rinalmo_2026_05_14/Dockerfile
+++ b/apps/r/rinalmo_2026_05_14/Dockerfile
@@ -18,16 +18,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
 
-RUN pip install --upgrade pip
+RUN pip install --upgrade pip setuptools wheel packaging
 
-# PyTorch 2.1.0 + CUDA 11.8 (matches environment.yml)
+# PyTorch 2.1.0 + CUDA 11.8 (matches environment.yml); numpy pinned to 1.x
+# because PyTorch 2.1.0 was compiled against NumPy 1.x ABI
 RUN pip install --no-cache-dir \
     torch==2.1.0 \
     torchvision==0.16.0 \
     torchaudio==2.1.0 \
+    numpy==1.26.0 \
     --index-url https://download.pytorch.org/whl/cu118
 
-# flash-attn 2.3.2 — requires CUDA devel headers + ninja for compilation
+# flash-attn 2.3.2 — requires CUDA devel headers + ninja; packaging must be
+# pre-installed because --no-build-isolation skips the isolated build env
 RUN pip install --no-cache-dir flash-attn==2.3.2 --no-build-isolation
 
 # Clone and install RiNALMo (installs: torch, numpy, ml_collections, packaging, gdown)

--- a/apps/r/rinalmo_2026_05_14/Dockerfile
+++ b/apps/r/rinalmo_2026_05_14/Dockerfile
@@ -47,16 +47,13 @@ RUN pip install --no-cache-dir \
     pytorch-lightning==2.1.3 \
     torchmetrics==1.2.1
 
-# Model weights (~2.5 GB for Giga) are NOT baked in.
-# Download at runtime via gdown, or mount a weights volume:
-#   docker run --gpus all -v /path/to/weights:/weights ...
-# Weights are auto-downloaded on first get_pretrained_model() call to ~/.cache/rinalmo/
+# Bake in fine-tuned weights for secondary structure prediction (bpRNA, ~2.5 GB).
+# The checkpoint includes the full model (LM + head) so no separate base weights needed.
+RUN mkdir -p /weights && \
+    wget -q --show-progress \
+         https://zenodo.org/records/15043668/files/rinalmo_giga_ss_bprna_ft.pt \
+         -O /weights/rinalmo_giga_ss_bprna_ft.pt
 
 WORKDIR /workspace
 
-# Usage:
-#   from rinalmo.pretrained import get_pretrained_model
-#   model, alphabet = get_pretrained_model(model_name="giga-v1")   # 650M
-#   model, alphabet = get_pretrained_model(model_name="mega-v1")   # 150M
-#   model, alphabet = get_pretrained_model(model_name="micro-v1")  # 35M
 CMD ["python", "-c", "from rinalmo.pretrained import get_pretrained_model; print('RiNALMo ready')"]

--- a/apps/r/rinalmo_2026_05_14/Dockerfile
+++ b/apps/r/rinalmo_2026_05_14/Dockerfile
@@ -1,0 +1,59 @@
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3.11 \
+    python3.11-dev \
+    python3-pip \
+    git \
+    wget \
+    ninja-build \
+    build-essential \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+
+RUN pip install --upgrade pip
+
+# PyTorch 2.1.0 + CUDA 11.8 (matches environment.yml)
+RUN pip install --no-cache-dir \
+    torch==2.1.0 \
+    torchvision==0.16.0 \
+    torchaudio==2.1.0 \
+    --index-url https://download.pytorch.org/whl/cu118
+
+# flash-attn 2.3.2 — requires CUDA devel headers + ninja for compilation
+RUN pip install --no-cache-dir flash-attn==2.3.2 --no-build-isolation
+
+# Clone and install RiNALMo (installs: torch, numpy, ml_collections, packaging, gdown)
+WORKDIR /opt
+RUN git clone https://github.com/lbcb-sci/RiNALMo.git
+
+WORKDIR /opt/RiNALMo
+RUN pip install --no-cache-dir .
+
+# Additional runtime dependencies from environment.yml
+RUN pip install --no-cache-dir \
+    einops==0.7.0 \
+    biopython==1.81 \
+    pytorch-lightning==2.1.3 \
+    torchmetrics==1.2.1
+
+# Model weights (~2.5 GB for Giga) are NOT baked in.
+# Download at runtime via gdown, or mount a weights volume:
+#   docker run --gpus all -v /path/to/weights:/weights ...
+# Weights are auto-downloaded on first get_pretrained_model() call to ~/.cache/rinalmo/
+
+WORKDIR /workspace
+
+# Usage:
+#   from rinalmo.pretrained import get_pretrained_model
+#   model, alphabet = get_pretrained_model(model_name="giga-v1")   # 650M
+#   model, alphabet = get_pretrained_model(model_name="mega-v1")   # 150M
+#   model, alphabet = get_pretrained_model(model_name="micro-v1")  # 35M
+CMD ["python", "-c", "from rinalmo.pretrained import get_pretrained_model; print('RiNALMo ready')"]


### PR DESCRIPTION
## Summary

- Adds `apps/r/rinalmo_2026_05_14/Dockerfile` for RiNALMo (RiboNucleic Acid Language Model)
- Registers entry in `apps/applications.json` under category `RNA-Structure`
- Adds `workflows/workflow-022` submodule: 3-node secondary structure prediction workflow

**Paper:** [Nature Communications, Jul 2025](https://www.nature.com/articles/s41467-025-60872-5)
**Upstream repo:** https://github.com/lbcb-sci/RiNALMo
**Workflow repo:** https://github.com/rogerwq/rinalmo-workflow

## Image details

| Item | Value |
|------|-------|
| Base | `nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04` |
| Python | 3.11 |
| PyTorch | 2.1.0 + CUDA 11.8 |
| flash-attn | 2.3.2 |
| NumPy | 1.26.0 (pinned — PyTorch 2.1.0 ABI) |
| scikit-learn | 1.3.1 |
| Model weights | bpRNA fine-tuned weights baked in at `/weights/rinalmo_giga_ss_bprna_ft.pt` |
| Image size | ~17.5 GB |

## Workflow (workflow-022)

| Node | Description |
|------|-------------|
| 00-input | Validate FASTA, normalise T→U, enforce 1022 nt limit |
| 01-predict | Run RiNALMo with `torch.autocast` fp16 + baked weights → contact map + dot-bracket |
| 02-report | Arc diagram HTML report with base-pair stats |

**GPU required** for node 01 — flash-attn uses fused QKV weights that require CUDA.
`TRITON_CACHE_DIR=/tmp/triton_cache` set in `run.sh` to avoid permission errors when HOME is unset.

## Test plan

- [x] `docker build` completes without errors
- [x] `docker run --rm rinalmo:2026_05_14` prints `RiNALMo ready` with no warnings
- [x] Full silva headless run verified — all 3 nodes pass
  - Input: tRNA-Phe-human (73 nt)
  - Output: 21 base pairs, dot-bracket `(((((((..((((........)))).(((((.......))))).....(((((.......)))))))))))).` — matches known cloverleaf structure

Closes #125