### PR TITLE
fix(workflow-020): use correct image references for production registry

### DIFF
--- a/workflows/workflow-020/00_download_inputs/.chiral/job.toml
+++ b/workflows/workflow-020/00_download_inputs/.chiral/job.toml
@@ -3,7 +3,7 @@ description = "Download BAM and GTF input files from a Zenodo record"
 outputs = ["*.bam", "*.gtf"]
 
 [container]
-image = "python:3.11-slim"
+image = "docker.io/library/python:3.11-slim"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-020/01_featurecounts/.chiral/job.toml
+++ b/workflows/workflow-020/01_featurecounts/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["*.bam", "*.gtf"]
 outputs = ["outputs/counts.csv", "outputs/counts_annotation.csv", "outputs/counts_table.csv"]
 
 [container]
-image = "chiral.sakuracr.jp/bioconductor:rna_seq_r_2025_12_27_v1"
+image = "bioconductor:rna_seq_r_2025_12_27_v1"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-020/02_deseq2/.chiral/job.toml
+++ b/workflows/workflow-020/02_deseq2/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["counts.csv"]
 outputs = ["outputs/merged.csv", "outputs/dds.rds", "outputs/res.rds", "outputs/pca_data.csv"]
 
 [container]
-image = "chiral.sakuracr.jp/bioconductor:rna_seq_r_2025_12_27_v1"
+image = "bioconductor:rna_seq_r_2025_12_27_v1"
 
 [scripts]
 run = "run.sh"

--- a/workflows/workflow-020/03_plots/.chiral/job.toml
+++ b/workflows/workflow-020/03_plots/.chiral/job.toml
@@ -4,7 +4,7 @@ inputs = ["dds.rds", "res.rds", "merged.csv", "pca_data.csv"]
 outputs = ["outputs/ma_plot.png", "outputs/volcano_plot.png", "outputs/pca_plot.png", "outputs/merged_with_regulation.csv"]
 
 [container]
-image = "chiral.sakuracr.jp/bioconductor:rna_seq_r_2025_12_27_v1"
+image = "bioconductor:rna_seq_r_2025_12_27_v1"
 
 [scripts]
 run = "run.sh"


### PR DESCRIPTION
## Problem

workflow-020 failed on production with image pull errors:

- Node 00: `Unable to find image 'ghcr.io/chiral-data/python:3.11-slim'` — production prepends `ghcr.io/chiral-data/` to bare image names
- Nodes 01–03: `Unable to find image 'chiral.sakuracr.jp/bioconductor:rna_seq_r_2025_12_27_v1'` — sakuracr.jp registry not accessible from production

## Fix

- **Node 00**: `python:3.11-slim` → `docker.io/library/python:3.11-slim` (explicit Docker Hub URL bypasses the prefix)
- **Nodes 01–03**: `chiral.sakuracr.jp/bioconductor:rna_seq_r_2025_12_27_v1` → `bioconductor:rna_seq_r_2025_12_27_v1` (bare name resolves correctly via `ghcr.io/chiral-data/`)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)