### PR TITLE
fix(workflow-005): read inputs from inputs/ folder instead of relative sibling paths

### DIFF
--- a/workflows/workflow-005/.chiral/workflow.toml
+++ b/workflows/workflow-005/.chiral/workflow.toml
@@ -11,5 +11,5 @@ description = "Machine Learning-Based Drug Discovery with Premium Interactive Vi
 # Node 3 depends on Node 2
 03-model-training = ["02-feature-engineering"]
 
-# Node 4 depends on Node 2 (scaler, ad_stats) and Node 3 (model)
-04-prediction = ["02-feature-engineering", "03-model-training"]
+# Node 4 depends on Node 0 (input CSV), Node 2 (scaler, ad_stats) and Node 3 (model)
+04-prediction = ["00-download-inputs", "02-feature-engineering", "03-model-training"]

--- a/workflows/workflow-005/04-prediction/.chiral/job.toml
+++ b/workflows/workflow-005/04-prediction/.chiral/job.toml
@@ -1,7 +1,7 @@
 name = "Prediction"
 description = "Make predictions on test SMILES"
-depends_on = ["02-feature-engineering", "03-model-training"]
-inputs = ["scaler.pkl", "ad_stats.json", "model.h5"]
+depends_on = ["00-download-inputs", "02-feature-engineering", "03-model-training"]
+inputs = ["scaler.pkl", "ad_stats.json", "model.h5", "*.csv"]
 outputs = ["outputs/data.json", "outputs/report.html", "outputs/predictions.csv"]
 
 [container]

--- a/workflows/workflow-005/04-prediction/run_prediction.py
+++ b/workflows/workflow-005/04-prediction/run_prediction.py
@@ -111,13 +111,13 @@ def run():
         
         try:
             import glob
-            csv_files = glob.glob("../01-data-preparation/inputs/*.csv")
+            csv_files = glob.glob("inputs/*.csv")
             if csv_files:
                 import pandas as pd
                 original_data = pd.read_csv(csv_files[0])
                 # Find SMILES column (case-insensitive)
                 smiles_col = next((col for col in original_data.columns if col.lower() == 'smiles'), None)
-                
+
                 if smiles_col:
                     test_smiles = original_data[smiles_col].dropna().tolist()
                     print(f"Loaded {len(test_smiles)} compounds from {csv_files[0]}")
@@ -125,7 +125,7 @@ def run():
                     print("ERROR: No 'smiles' column found in input CSV")
                     return
             else:
-                print("ERROR: No CSV file found in ../01-data-preparation/inputs/")
+                print("ERROR: No CSV file found in inputs/")
                 return
         except Exception as e:
             print(f"ERROR loading SMILES from input CSV: {e}")
@@ -203,7 +203,7 @@ def run():
     drug_names = {}
     try:
         import glob
-        csv_files = glob.glob("../01-data-preparation/inputs/*.csv")
+        csv_files = glob.glob("inputs/*.csv")
         if csv_files:
             import pandas as pd
             original_data = pd.read_csv(csv_files[0])

--- a/workflows/workflow-005/04-prediction/run_prediction.py
+++ b/workflows/workflow-005/04-prediction/run_prediction.py
@@ -51,11 +51,6 @@ def check_ad(features, ad_stats_path):
         results.append("IN" if is_in else "OUT")
     return results
 
-def find_file(filename, search_path):
-    for root, dirs, files in os.walk(search_path):
-        if filename in files:
-            return os.path.join(root, filename)
-    return None
 
 import re
 
@@ -165,23 +160,15 @@ def run():
     print(f"\nPredicting on {len(test_smiles)} compounds...")
 
     
-    # Silva shared workspace: read directly from previous nodes' outputs
-    model_path = os.path.join("..", "03-model-training", "outputs", "model.h5")
-    if not os.path.exists(model_path): model_path = find_file("model.h5", "..")
-    
-    scaler_path = os.path.join("..", "02-feature-engineering", "outputs", "scaler.pkl")
-    if not os.path.exists(scaler_path): scaler_path = find_file("scaler.pkl", "..")
-    
-    ad_path = os.path.join("..", "02-feature-engineering", "outputs", "ad_stats.json")
-    if not os.path.exists(ad_path): ad_path = find_file("ad_stats.json", "..")
-    
-    if not model_path:
-        print("Model not found.")
-        for root, dirs, files in os.walk(".."):
-            if "model.h5" in files:
-                print(f"  Found in: {root}")
-        return
-        
+    model_path = "inputs/model.h5"
+    scaler_path = "inputs/scaler.pkl"
+    ad_path = "inputs/ad_stats.json"
+
+    for path in [model_path, scaler_path, ad_path]:
+        if not os.path.exists(path):
+            print(f"Required input not found: {path}")
+            return
+
     print(f"Found inputs: {model_path}, {scaler_path}, {ad_path}")
 
     # 1. Compute Descriptors


### PR DESCRIPTION
Closes #140

## Summary

- `run_prediction.py` was loading `model.h5`, `scaler.pkl`, and `ad_stats.json` via `../node/outputs/` relative paths, which fail inside the Docker container where sibling directories don't exist
- The input CSV was loaded via `../01-data-preparation/inputs/*.csv`, same problem
- `workflow.toml` was missing `00-download-inputs` as a dependency for `04-prediction`, so Silva never copied `SpikeRBD_DD.csv` into `04-prediction/inputs/`
- The cascading result: `outputs/data.json` was never written → `generate_prediction_report.py` silently returned early → `report.html` was never produced

## Changes

- `run_prediction.py`: switch all artifact paths to `inputs/` and CSV glob to `inputs/*.csv`; remove dead `find_file` helper and unreachable debug walk
- `04-prediction/.chiral/job.toml`: add `*.csv` to `inputs` and `00-download-inputs` to `depends_on`
- `.chiral/workflow.toml`: add `00-download-inputs` to `04-prediction` dependencies (this is what Silva actually uses to copy files)

## Verified

Ran `silva ~/dev/collab-workflows/workflows/workflow-005` end-to-end — node 04 now loads all 3010 compounds, runs predictions, and produces `outputs/report.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)