### PR TITLE
fix(workflow-005): remove debug_env.txt from prediction node outputs

### DIFF
--- a/workflows/workflow-005/04-prediction/run_prediction.py
+++ b/workflows/workflow-005/04-prediction/run_prediction.py
@@ -92,10 +92,6 @@ def get_param(param_name, default_if_missing=None):
     raise ValueError(f"Parameter {param_name} missing (Env Var and job.toml default)")
 
 def run():
-    with open("outputs/debug_env.txt", "w") as f:
-        for k, v in os.environ.items():
-            f.write(f"{k}={v}\n")
-    
     # Check if we should predict on all data from input CSV
     predict_all = os.environ.get("PREDICT_ALL_DATA", "true").lower() == "true"
     


### PR DESCRIPTION
Closes #145

## Summary

- Removes the `debug_env.txt` env var dump from `run()` in `04-prediction/run_prediction.py` — it was a debug leftover and should not appear as a workflow output artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)