### PR TITLE
Add AI-accelerated workflow building guide for interns

### DIFF
--- a/AI_WORKFLOW_GUIDE.md
+++ b/AI_WORKFLOW_GUIDE.md
@@ -1,0 +1,381 @@
+# AI-Accelerated Workflow Building Guide
+
+How to use Claude Code to build Silva workflows faster — a companion to the [Silva Migration Guide](./SILVA_MIGRATION_GUIDE.md).
+
+**Authors:** Dev-App Team, Chiral Inc.
+**Last Updated:** June 2026
+
+---
+
+## How This Guide Relates to the Migration Guide
+
+The [Silva Migration Guide](./SILVA_MIGRATION_GUIDE.md) defines **what** to build — the structure, conventions, and manual process. This guide defines **how** to use AI (Claude Code) to accelerate each step.
+
+Read the migration guide first. Then use this guide as an overlay.
+
+**Core principle:** AI output quality is proportional to context quality. The most important thing you can do is feed Claude the right context before asking it to generate anything.
+
+### The Development Loop
+
+```
+Prepare Context → Scaffold → Node-by-Node → Docker Debug → Review → Report → E2E Test
+```
+
+Each section below maps to a step in this loop.
+
+---
+
+## 1. What Context Does AI Need
+
+Before asking Claude to build anything, prepare this checklist of context. Copy-paste or point Claude to these files at the start of your conversation.
+
+### 1.1 Similar Examples from This Repo
+
+Pick 1–2 existing workflows with similar characteristics as references. Feed Claude their `workflow.toml`, one representative `job.toml`, and the README.
+
+| Your tool looks like... | Reference workflow | Key files to share |
+|---|---|---|
+| Simple pip-installable Python package | workflow-014 (ADMET-AI) | `workflows/workflow-014/.chiral/workflow.toml`, `workflows/workflow-014/Dockerfile` |
+| Complex conda environment | workflow-004 (AutoDock Vina) | `workflows/workflow-004/Dockerfile` |
+| GPU + large model weights | workflow-012 (Boltz-2) | `workflows/workflow-012/.chiral/workflow.toml`, `workflows/workflow-012/README.md` |
+| Package with upstream bugs to patch | workflow-015 (mDeepFRI) | `workflows/workflow-015/Dockerfile` |
+| Fan-out comparison (multiple models) | workflow-018 (Boltz-2 vs Chai-1) | `workflows/workflow-018/.chiral/workflow.toml`, `workflows/workflow-018/README.md` |
+
+### 1.2 Workflow Proposal (Node Structure)
+
+Write your proposed node structure as a markdown table before starting implementation. If you have a Google Doc proposal, ask Claude to convert it:
+
+> "Convert this proposal document to a node structure table with columns: Node number, Name, Description, Inputs, Outputs, GPU required. Follow the format used in `workflows/workflow-018/README.md`."
+
+Example node structure:
+
+| Node | Name | Description | Inputs | Outputs | GPU |
+|------|------|-------------|--------|---------|-----|
+| 00 | Download | Fetch sequence from UniProt | (user params) | `sequence.fasta` | No |
+| 01 | Validate | Check input format | `sequence.fasta` | `validated.fasta` | No |
+| 02 | Predict | Run structure prediction | `validated.fasta` | `structure.cif`, `confidence.json` | Yes |
+| 03 | Report | Generate HTML dashboard | `structure.cif`, `confidence.json` | `report.html` | No |
+
+### 1.3 GitHub Issue Number
+
+Create a GitHub issue **before** you start building (see [Migration Guide Section 8.2](./SILVA_MIGRATION_GUIDE.md#82-step-1--open-a-github-issue)). Give Claude the issue number so it can include `Closes #NNN` in commits and PR descriptions.
+
+### 1.4 The Tool's Original Repo + References
+
+Feed Claude as much of the following as you can find:
+
+- **GitHub URL** and README of the tool
+- **Installation instructions** (pip install, conda, etc.)
+- **CLI help output** (`tool --help`) or Python API usage example
+- **Paper** (if applicable) — at minimum the abstract and methods section
+- **Example input/output** — what the tool actually takes and produces
+
+This is what Claude needs to write correct prediction scripts. Without it, Claude will guess the API and get it wrong.
+
+### 1.5 The .chiral Config Format
+
+Share one example of each config file so Claude knows the exact format:
+
+- **workflow.toml**: `workflows/workflow-018/.chiral/workflow.toml`
+- **job.toml**: `workflows/workflow-018/00-download/.chiral/job.toml`
+
+Key things Claude needs to know about the format:
+- Dependencies are declared centrally in `workflow.toml`, not in individual `job.toml` files
+- Parameters use `env = "PARAM_..."` to map to environment variables
+- Only nodes with upstream dependencies appear in `[dependencies]` (the first node is omitted)
+
+---
+
+## 2. How to Prepare a Dockerfile
+
+There are 4 common Dockerfile patterns in this repo. Tell Claude which pattern fits your tool.
+
+### Pattern 1: Minimal pip (simplest)
+
+For tools available as a Python package. Example: `workflows/workflow-014/Dockerfile`
+
+```dockerfile
+FROM continuumio/miniconda3
+ENV USER=silva HOME=/tmp MPLCONFIGDIR=/tmp/matplotlib
+RUN pip install --no-cache-dir admet-ai
+WORKDIR /workspace
+```
+
+**Prompt:**
+> "Create a Dockerfile for [tool]. It's installable via `pip install [package]`. Use the same pattern as `workflows/workflow-014/Dockerfile`. Pin the package version."
+
+### Pattern 2: Complex conda environment
+
+For tools with heavy native dependencies. Example: `workflows/workflow-016/Dockerfile`
+
+**Prompt:**
+> "Create a Dockerfile for [tool] based on `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04`. It needs a conda environment with [packages]. Install Miniconda, create the environment from an environment.yml, and set the conda env as default. Follow the pattern in `workflows/workflow-016/Dockerfile`."
+
+### Pattern 3: GPU + model weight caching
+
+For ML models that download large weights at runtime. Pre-download them at build time so prediction runs offline.
+
+**Prompt:**
+> "Create a Dockerfile for [tool]. It downloads model weights from HuggingFace on first run — we need to pre-cache them at build time. Use `huggingface-cli download [model]` or the tool's download command. Set `HF_HOME=/models`. Add a smoke test: `CMD python -c 'import [tool]; print(\"OK\")'`."
+
+### Pattern 4: Package patching
+
+For tools with known bugs in installed packages. Example: `workflows/workflow-015/Dockerfile`
+
+**Prompt:**
+> "Create a Dockerfile for [tool]. After pip install, we need to patch [file] in the installed package to fix [bug]. Use a Python heredoc or `sed` to apply the fix. See `workflows/workflow-015/Dockerfile` for the pattern."
+
+### Dockerfile Checklist
+
+- [ ] Pin all package versions (`pip install package==1.2.3`)
+- [ ] Use `--no-cache-dir` with pip
+- [ ] Clean apt caches (`rm -rf /var/lib/apt/lists/*`)
+- [ ] Set `WORKDIR /workspace`
+- [ ] Pre-download any model weights or data at build time
+
+---
+
+## 3. How to Test a Dockerfile Works
+
+### Build
+
+```bash
+docker build -t my-tool:test -f workflows/workflow-XXX/Dockerfile .
+```
+
+### Smoke test
+
+```bash
+docker run --rm my-tool:test python -c "import my_tool; print('OK')"
+```
+
+### GPU test (if applicable)
+
+```bash
+docker run --rm --gpus all my-tool:test nvidia-smi
+docker run --rm --gpus all my-tool:test python -c "import torch; print(torch.cuda.is_available())"
+```
+
+### Debugging build failures with AI
+
+Copy the full error output and paste it to Claude:
+
+> "This Dockerfile build failed with the following error: [paste]. Here is the Dockerfile: [paste]. Fix the issue."
+
+---
+
+## 4. How to Build Node Structure with AI
+
+### Step 1: Scaffold
+
+Ask Claude to generate the entire directory structure in one shot:
+
+> "Scaffold a Silva workflow called 'workflow-XXX' with the following node structure: [paste your table from Section 1.2]. Use `.chiral/workflow.toml` for the DAG and `.chiral/job.toml` per node. Follow the conventions in `workflows/workflow-018/`. Include a README and example input file."
+
+This creates all directories, config files, `run.sh` scripts, and the README in one pass.
+
+### Step 2: Implement node by node
+
+After scaffolding, implement each node as a separate step. **Do not ask Claude to write all nodes at once** — build and test one at a time.
+
+> "Implement node 02-predict for workflow-XXX. It reads `validated.fasta` from `./inputs/` and writes `structure.cif` to `./outputs/`. The Docker image is `my-tool:test`. Here is the tool's Python API: [paste]. Read parameters from `PARAM_*` env vars as defined in the job.toml."
+
+### Step 3: Commit each node separately
+
+Follow the commit pattern used in this repo:
+
+```
+feat(workflow-XXX): scaffold [name] workflow
+feat(workflow-XXX): add 00-download node
+feat(workflow-XXX): add 01-validate-inputs node
+feat(workflow-XXX): add 02-predict node
+feat(workflow-XXX): add 03-report node
+```
+
+---
+
+## 5. How to Debug Each Node with Docker + Sample Input
+
+### Running a single node locally
+
+```bash
+# Create test directories
+mkdir -p /tmp/test-node/inputs /tmp/test-node/outputs
+
+# Copy test input files
+cp workflows/workflow-XXX/input_files/test.yaml /tmp/test-node/inputs/
+
+# Run the node
+docker run --rm \
+  -v /tmp/test-node/inputs:/workspace/inputs \
+  -v /tmp/test-node/outputs:/workspace/outputs \
+  -v $(pwd)/workflows/workflow-XXX/02-predict:/workspace \
+  -w /workspace \
+  -e PARAM_NUM_LOOPS=3 \
+  -e PARAM_METHOD=default \
+  my-tool:test bash run.sh
+```
+
+Key points:
+- Mount `inputs/` and `outputs/` as volumes
+- Mount the node directory to `/workspace` so `run.sh` and scripts are available
+- Set `PARAM_*` environment variables manually (Silva does this automatically in production)
+- For GPU nodes, add `--gpus all`
+
+### The debug loop
+
+1. Run the node with Docker
+2. If it fails, copy the error output
+3. Paste to Claude: "This node failed with: [error]. Here is run.sh: [paste]. Here is the Python script: [paste]. Fix the issue."
+4. Apply the fix, re-run
+5. Repeat until the node produces correct output files in `/tmp/test-node/outputs/`
+
+### Chaining nodes
+
+To test node B that depends on node A's output:
+
+```bash
+# Run node A
+docker run --rm \
+  -v /tmp/node-a/inputs:/workspace/inputs \
+  -v /tmp/node-a/outputs:/workspace/outputs \
+  ...
+
+# Feed A's output as B's input
+cp /tmp/node-a/outputs/* /tmp/node-b/inputs/
+
+# Run node B
+docker run --rm \
+  -v /tmp/node-b/inputs:/workspace/inputs \
+  -v /tmp/node-b/outputs:/workspace/outputs \
+  ...
+```
+
+---
+
+## 6. Code Review — Keep It Simple and Working
+
+### Self-review with AI
+
+Before pushing, ask Claude to check your workflow:
+
+> "Review this workflow for correctness. Check:
+> 1. All `outputs` declared in each `job.toml` are actually written by the scripts
+> 2. All `inputs` declared match what the upstream node produces
+> 3. The `[dependencies]` in `workflow.toml` match the actual data flow
+> 4. All shell scripts have `set -e`
+> 5. All Python scripts create `./outputs/` before writing
+> 6. No hardcoded absolute paths
+> 7. Parameters are read from `PARAM_*` env vars, not hardcoded"
+
+### Handling PR review feedback
+
+When you receive review comments on your PR:
+
+1. Copy the review comments
+2. Paste to Claude: "Here are the PR review comments: [paste]. Apply these fixes to the relevant files."
+3. Commit with: `fix(workflow-XXX): address PR review comments`
+
+---
+
+## 7. How to Prepare a Report Template
+
+Most workflows end with a visualization node that generates a self-contained HTML report. The report is a single `.html` file with all libraries loaded from CDN — no local assets needed.
+
+### Recommended libraries
+
+| Library | CDN | Use when |
+|---|---|---|
+| **Bootstrap 5** | `cdn.jsdelivr.net/npm/bootstrap@5.3.3` | Always — responsive layout |
+| **Plotly.js** | `cdn.plot.ly/plotly-2.35.2.min.js` | Charts, heatmaps, radar plots |
+| **3Dmol.js** | `3Dmol.org/build/3Dmol-min.js` | Simple protein/molecule 3D viewer (lightweight, easy API) |
+| **Mol\*** (Molstar) | `cdn.jsdelivr.net/npm/molstar@latest` | Advanced 3D viewer with toggle, superposition, multi-model support |
+| **SMILES-drawer** | `cdn.jsdelivr.net/npm/smiles-drawer` | 2D molecule structure rendering from SMILES strings |
+
+Pick the libraries that fit your workflow's output. Not every report needs a 3D viewer.
+
+### Recommended conventions for new workflows
+
+> **Note:** Existing workflows in this repo vary in how they handle report I/O. The conventions below are the recommended standard for all new workflows.
+
+1. **Read inputs from `./inputs/`** using hardcoded paths (not argparse). This aligns with how Silva populates the inputs directory from upstream node outputs.
+2. **Write the report to `./outputs/report.html`**. This follows the same `./outputs/` convention as every other node and matches the `outputs` declaration in `job.toml`.
+3. **Read parameters from `PARAM_*` environment variables**, not hardcoded values or argparse flags.
+4. **Embed all data inline** as JavaScript variables in the HTML. The report must be fully self-contained.
+
+### Prompt for report generation
+
+> "Generate a Python script `generate_report.py` that reads [output files] from `./inputs/` and writes a self-contained HTML report to `./outputs/report.html`. Use Bootstrap 5 for layout and Plotly.js for charts, both loaded from CDN. Embed all data inline as JavaScript variables. Read inputs from `./inputs/` directly (no argparse). Create `./outputs/` with `os.makedirs`."
+
+### Reference report scripts
+
+- **ADMET dashboard** (radar charts + data tables): `workflows/workflow-014/04_visualize/generate_report.py`
+- **Structure comparison** (Mol* 3D viewers + metric plots): `workflows/workflow-018/05-visualize/generate_report.py`
+- **Docking results** (3Dmol.js 3D viewer): `workflows/workflow-017/04_visualize/generate_report_3dmol.py`
+- **ML prediction** (SMILES-drawer molecules): `workflows/workflow-005/04-prediction/generate_prediction_report.py`
+
+---
+
+## 8. End-to-End Testing
+
+### Phase 1: Docker chain test
+
+Run all nodes sequentially using Docker (as described in [Section 5](#5-how-to-debug-each-node-with-docker--sample-input)). This validates the full file flow without needing Silva installed.
+
+Verify:
+- [ ] Each node produces the expected output files
+- [ ] Files pass correctly between nodes (output of node N = input of node N+1)
+- [ ] The final report.html opens in a browser and looks correct
+
+### Phase 2: Silva test
+
+Once the Docker chain works, test with Silva:
+
+```bash
+export SILVA_WORKFLOW_HOME=/path/to/directory/containing/your/workflow
+./silva
+```
+
+Select your workflow and run. All nodes should complete with green checkmarks.
+
+### Troubleshooting with AI
+
+> "The Silva workflow runs nodes 00 through 02 successfully, but node 03 fails with: [error]. Here is the workflow.toml: [paste]. Here is node 03's job.toml: [paste]. Here is run.sh: [paste]. The inputs directory contains: [ls output]. What is wrong?"
+
+---
+
+## 9. Prompt Templates Quick Reference
+
+| Phase | Prompt |
+|-------|--------|
+| **Scaffold** | "Scaffold a Silva workflow for [tool] with nodes: [table]. Use `.chiral/` config format. Follow `workflows/workflow-018/` conventions." |
+| **Dockerfile** | "Create a Dockerfile for [tool] based on [base image]. Pin versions, use `--no-cache-dir`, set `WORKDIR /workspace`." |
+| **Node implementation** | "Implement node [NN]-[name]. It reads [inputs] from `./inputs/` and writes [outputs] to `./outputs/`. Here is the tool's API: [paste]." |
+| **Debug** | "This node failed with: [error]. Here is run.sh and the Python script. Fix the issue." |
+| **Report** | "Generate `generate_report.py` that reads [files] and writes a self-contained HTML report with Bootstrap 5 + Plotly.js." |
+| **Review** | "Review this workflow: check outputs match job.toml, dependencies match data flow, no hardcoded paths." |
+| **PR description** | "Write a PR description for workflow-XXX. Closes #[issue]. Include summary, workflow structure, and verification checklist." |
+| **Commit message** | "Write a commit message for this change. Use the format `feat(workflow-XXX): ...` or `fix(workflow-XXX): ...`." |
+
+---
+
+## 10. What Else AI Can Help With
+
+- **Generating test input data**: "Generate a small valid [YAML/FASTA/SDF/CSV] test file for [tool]. Include 2–3 entries with realistic data."
+- **Writing the GitHub issue**: "Draft a GitHub issue using the template from the migration guide for [tool]. Here is the tool's README: [paste]."
+- **Converting existing scripts**: "Refactor this script to use `./inputs/` and `./outputs/` conventions. Read parameters from `PARAM_*` env vars instead of hardcoded values."
+- **Troubleshooting dependency conflicts**: "This pip install failed with: [error]. Here is the Dockerfile. Fix the dependency conflict."
+- **Updating applications.json**: "Add an entry to `apps/applications.json` for [tool] following the existing format."
+
+---
+
+## Appendix: Reference Workflow Map
+
+| Characteristic | Workflow | Path |
+|---|---|---|
+| Simple pip tool, linear pipeline | workflow-014 (ADMET-AI) | `workflows/workflow-014/` |
+| Pip + package patching | workflow-015 (mDeepFRI) | `workflows/workflow-015/` |
+| Complex conda + GPU | workflow-016 (DiffDock-PP) | `workflows/workflow-016/` |
+| Fan-out comparison (parallel models) | workflow-018 (Boltz-2 vs Chai-1) | `workflows/workflow-018/` |
+| Multi-step ML pipeline | workflow-005 (QSAR) | `workflows/workflow-005/` |
+| Protein docking | workflow-017 (LightDock) | `workflows/workflow-017/` |

--- a/AI_WORKFLOW_GUIDE.md
+++ b/AI_WORKFLOW_GUIDE.md
@@ -81,7 +81,7 @@ Share one example of each config file so Claude knows the exact format:
 
 Key things Claude needs to know about the format:
 - Dependencies are declared centrally in `workflow.toml`, not in individual `job.toml` files
-- Parameters use `env = "PARAM_..."` to map to environment variables
+- Silva auto-maps each parameter key to an environment variable: `[params.my_param]` → `PARAM_MY_PARAM`. Scripts read these with shell defaults (e.g., `${PARAM_MY_PARAM:-value}`) or `os.environ.get()` in Python. You do **not** need to add an `env` field.
 - Only nodes with upstream dependencies appear in `[dependencies]` (the first node is omitted)
 
 ---
@@ -111,12 +111,33 @@ For tools with heavy native dependencies. Example: `workflows/workflow-016/Docke
 **Prompt:**
 > "Create a Dockerfile for [tool] based on `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04`. It needs a conda environment with [packages]. Install Miniconda, create the environment from an environment.yml, and set the conda env as default. Follow the pattern in `workflows/workflow-016/Dockerfile`."
 
-### Pattern 3: GPU + model weight caching
+### Pattern 3: Pre-caching model weights
 
-For ML models that download large weights at runtime. Pre-download them at build time so prediction runs offline.
+Many ML tools download large model weights (often several GB) on first run. If you don't pre-download them into the Docker image at build time, every prediction run has to re-download — slow and may fail without internet access.
+
+There are several ways to handle this, depending on how the tool loads its models:
+
+**a) Tool's built-in download command** (simplest). Example: `workflows/workflow-015/Dockerfile`
+```dockerfile
+# mDeepFRI provides its own download command
+RUN mDeepFRI get-models -o /opt/mdeepfri-weights -v 1.1
+```
+
+**b) PyTorch Hub** (for models loaded via `torch.hub.load`). Example: `workflows/workflow-016/Dockerfile`
+```dockerfile
+ENV TORCH_HOME=/opt/torch_cache
+RUN python -c "import torch; torch.hub.set_dir('/opt/torch_cache'); \
+    torch.hub.load('facebookresearch/esm:main', 'esm2_t33_650M_UR50D')"
+```
+
+**c) HuggingFace CLI** (for models hosted on HuggingFace Hub)
+```dockerfile
+ENV HF_HOME=/models
+RUN huggingface-cli download [org/model-name]
+```
 
 **Prompt:**
-> "Create a Dockerfile for [tool]. It downloads model weights from HuggingFace on first run — we need to pre-cache them at build time. Use `huggingface-cli download [model]` or the tool's download command. Set `HF_HOME=/models`. Add a smoke test: `CMD python -c 'import [tool]; print(\"OK\")'`."
+> "Create a Dockerfile for [tool]. It downloads model weights on first run — we need to pre-cache them at build time. [Describe how the tool loads weights: torch.hub, HuggingFace, or a built-in download command]. Add a smoke test: `CMD python -c 'import [tool]; print(\"OK\")'`."
 
 ### Pattern 4: Package patching
 
@@ -143,11 +164,15 @@ For tools with known bugs in installed packages. Example: `workflows/workflow-01
 docker build -t my-tool:test -f workflows/workflow-XXX/Dockerfile .
 ```
 
+This reads the Dockerfile and builds an image named `my-tool:test`. The `-t` flag gives it a name (tag) so you can reference it later. The `.` at the end means "use the current directory as the build context."
+
 ### Smoke test
 
 ```bash
 docker run --rm my-tool:test python -c "import my_tool; print('OK')"
 ```
+
+`docker run` creates a temporary container from the image and runs a command inside it. `--rm` automatically deletes the container when it exits (otherwise stopped containers pile up on disk).
 
 ### GPU test (if applicable)
 
@@ -165,6 +190,17 @@ Copy the full error output and paste it to Claude:
 ---
 
 ## 4. How to Build Node Structure with AI
+
+### Node naming convention
+
+Existing workflows in the repo use mixed naming styles (hyphens, underscores, etc.). For **new workflows**, use `NN-kebab-case` — two-digit zero-padded number followed by a hyphenated name. This matches `workflows/workflow-018/` which is the most consistent reference:
+
+```
+00-download/
+01-validate-inputs/
+02-predict/
+03-report/
+```
 
 ### Step 1: Scaffold
 
@@ -217,10 +253,11 @@ docker run --rm \
 ```
 
 Key points:
-- Mount `inputs/` and `outputs/` as volumes
-- Mount the node directory to `/workspace` so `run.sh` and scripts are available
-- Set `PARAM_*` environment variables manually (Silva does this automatically in production)
-- For GPU nodes, add `--gpus all`
+- The `-v host_path:container_path` flag is a **volume mount** — it makes a directory on your machine visible inside the container. For example, `-v /tmp/test-node/inputs:/workspace/inputs` means the container sees your local `/tmp/test-node/inputs` folder as `/workspace/inputs`.
+- Mount `inputs/` and `outputs/` so the container can read test data and write results back to your machine
+- Mount the node directory to `/workspace` so `run.sh` and scripts are available inside the container
+- `-e PARAM_NUM_LOOPS=3` sets environment variables inside the container (Silva does this automatically in production)
+- For GPU nodes, add `--gpus all` (requires [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed on the host)
 
 ### The debug loop
 

--- a/SILVA_MIGRATION_GUIDE.md
+++ b/SILVA_MIGRATION_GUIDE.md
@@ -65,7 +65,6 @@ my-workflow/
 ├── 02_second_step/
 │   ├── .chiral/
 │   │   └── job.toml
-│   ├── pre_run.sh
 │   ├── run.sh
 │   ├── my_script.py
 │   └── outputs/
@@ -111,14 +110,22 @@ outputs     = ["result.csv", "plot.png"]
 image = "python:3.11-slim"
 
 [scripts]
-pre = "pre_run.sh"    # Optional: install dependencies
-run = "run.sh"         # Required: main execution
+run = "run.sh"
 
 [params.threshold]
 type    = "float"
 default = 0.5
 hint    = "Filtering threshold"
-env     = "PARAM_THRESHOLD"
+```
+
+Silva automatically maps each parameter key to an environment variable named `PARAM_<UPPERCASE_KEY>`. For example, `[params.threshold]` becomes `PARAM_THRESHOLD` — you do **not** need to declare an `env` field. Your scripts read these with defaults:
+
+```bash
+THRESHOLD="${PARAM_THRESHOLD:-0.5}"
+```
+
+```python
+threshold = float(os.environ.get("PARAM_THRESHOLD", "0.5"))
 ```
 
 **Key fields in job.toml:**
@@ -129,30 +136,30 @@ env     = "PARAM_THRESHOLD"
 | `inputs` | No | List of filenames this job needs. Silva copies them from dependency outputs into `./inputs/` |
 | `outputs` | Yes | List of filenames this job produces. Must be written to `./outputs/` |
 | `[container].image` | Yes | Docker image name and tag |
-| `[scripts].pre` | No | Runs before `run`. Typically installs pip packages |
 | `[scripts].run` | Yes | Main execution script |
-| `[params.*].env` | No | Maps the parameter to an environment variable (e.g., `PARAM_THRESHOLD`) |
 
 > **Note:** Job dependencies are declared centrally in `workflow.toml` under `[dependencies]`, not in individual `job.toml` files.
 
 ### File Passing Between Jobs
 
-Silva uses a simple convention for passing data between jobs:
+Silva automatically handles data flow between jobs — you don't copy files manually. Here's how it works:
 
 - Each job writes its output files to `./outputs/`
 - Downstream jobs declare `inputs` in their `.chiral/job.toml` (dependencies are set in `workflow.toml`)
-- Silva automatically copies the matching output files into `./inputs/` of the dependent job
+- When a job finishes, Silva copies its output files into `./inputs/` of every dependent job that lists them
 
 ```
-01_prepare/outputs/data.csv  →  02_process/inputs/data.csv
+01_prepare/outputs/data.csv  →  (Silva copies automatically)  →  02_process/inputs/data.csv
 ```
+
+You only need to make sure the filenames match: what one job writes to `./outputs/` must match what the next job declares in `inputs`.
 
 ### Parameters
 
 Parameters are defined in TOML config files and passed to scripts as **environment variables**.
 
 - **Workflow-level parameters** — Defined in `.chiral/workflow.toml` under `[params.*]`. These are shared across all jobs.
-- **Job-level parameters** — Defined in `.chiral/job.toml` under `[params.*]`. These are specific to a single job. Each parameter has an `env` field that maps it to an environment variable name (e.g., `PARAM_THRESHOLD`).
+- **Job-level parameters** — Defined in `.chiral/job.toml` under `[params.*]`. These are specific to a single job. Silva auto-maps each param key to `PARAM_<UPPERCASE_KEY>` (e.g., `[params.threshold]` → `PARAM_THRESHOLD`).
 
 Your Python scripts read parameters at runtime using `os.environ.get()`:
 
@@ -345,37 +352,34 @@ inputs  = ["input.sdf"]
 outputs = ["results.csv"]
 
 [container]
-image = "python:3.11-slim"
+image = "my-tool:1.0"
 
 [scripts]
-pre = "pre_run.sh"
 run = "run.sh"
 
 [params.threshold]
 type    = "float"
 default = 0.5
 hint    = "Filtering threshold"
-env     = "PARAM_THRESHOLD"
 
 [params.method]
 type    = "string"
 default = "default"
 hint    = "Computation method"
-env     = "PARAM_METHOD"
 ```
 
-**`02_compute/pre_run.sh`:**
-```bash
-#!/bin/bash
-set -e
-pip install some-package another-package
-```
+> **Note:** All dependencies are baked into the Docker image (via the Dockerfile). The container image listed here should already have everything installed. See the [AI Workflow Guide](./AI_WORKFLOW_GUIDE.md#2-how-to-prepare-a-dockerfile) for Dockerfile patterns.
 
 **`02_compute/run.sh`:**
 ```bash
 #!/bin/bash
 set -e
-echo "Running computation..."
+
+# Silva auto-maps param keys to PARAM_<UPPERCASE_KEY> env vars
+THRESHOLD="${PARAM_THRESHOLD:-0.5}"
+METHOD="${PARAM_METHOD:-default}"
+
+echo "Running computation (threshold=$THRESHOLD, method=$METHOD)..."
 python3 compute.py
 echo "Done. Results written to outputs/"
 ```
@@ -393,6 +397,8 @@ Browse existing workflows in this repo for concrete examples — each tool's scr
 
 ### Docker Image Selection Guide
 
+A **Docker image** is a pre-built package containing an operating system, programming language, and libraries — everything your script needs to run. You specify which image each node uses in `job.toml`.
+
 | Use Case | Recommended Image |
 |----------|-------------------|
 | File validation only (bash) | `ubuntu:22.04` |
@@ -400,17 +406,11 @@ Browse existing workflows in this repo for concrete examples — each tool's scr
 | Needs conda packages | `continuumio/miniconda3` |
 | Heavy scientific stack (numpy, scipy, etc.) | `python:3.11-slim` + pip install |
 | GPU-accelerated computation | `nvidia/cuda:12.x-runtime-ubuntu22.04` |
-| Custom/complex environment | Write a `Dockerfile` in the job folder |
+| Custom/complex environment | Write a `Dockerfile` in the workflow root |
 
 **Prefer `python:3.11-slim`** unless you have a specific reason for another image. It's small, fast to pull, and works with pip for most Python packages.
 
-### pre_run.sh Best Practices
-
-- Always start with `set -e` to fail fast on errors
-- Install packages with `pip install` — avoid `pip install --upgrade pip` unless needed
-- For GitHub-hosted packages: `pip install git+https://github.com/user/repo.git`
-- Pin versions when possible: `pip install numpy==1.26.4 pandas==2.2.0`
-- Keep it minimal — only install what this specific node needs
+For workflows that need packages not available in a standard image, write a `Dockerfile` that installs everything at **build time** (not at runtime). See the [AI Workflow Guide](./AI_WORKFLOW_GUIDE.md#2-how-to-prepare-a-dockerfile) for common Dockerfile patterns.
 
 ---
 
@@ -424,7 +424,7 @@ Browse existing workflows in this repo for concrete examples — each tool's scr
    cd silva
    cargo build --release
    ```
-   (Requires Rust toolchain and Docker)
+   (Requires [Rust toolchain](https://rustup.rs/) and Docker)
 
 2. **Set the workflow home directory:**
    ```bash
@@ -641,7 +641,7 @@ git commit -m "Add README and test data"
 
 **Good commit messages:**
 - `Add node 01: input validation for ADMET workflow`
-- `Fix pre_run.sh: pin numpy version to avoid compatibility issue`
+- `Fix Dockerfile: pin numpy version to avoid compatibility issue`
 - `Add verification screenshots`
 
 **Bad commit messages:**
@@ -806,7 +806,7 @@ git commit -m "Your message"
 
 3. **Not creating the `outputs/` directory.** In Python scripts, always include `os.makedirs("./outputs", exist_ok=True)`.
 
-4. **Installing packages in `run.sh` instead of `pre_run.sh`.** Package installation goes in `pre_run.sh` (the `pre` script). Keep `run.sh` for actual computation only.
+4. **Installing packages at runtime instead of in the Dockerfile.** All dependencies should be baked into the Docker image at build time. Don't `pip install` in `run.sh` — it slows down every run and makes results non-reproducible.
 
 5. **Declaring outputs that aren't actually written.** If your `job.toml` says `outputs = ["result.csv"]`, your script must write exactly `./outputs/result.csv`. Mismatches cause silent failures.
 
@@ -821,7 +821,7 @@ git commit -m "Your message"
 - **Look at the tool's test suite** for example usage and test data.
 - **Read the tool's source code**, not just the README. The API often supports more than what's documented.
 - **Use `python:3.11-slim` as your default image.** Only switch to something else if you have a reason.
-- **Keep pre_run.sh minimal.** Every extra package adds to container startup time.
+- **Bake all dependencies into the Docker image.** Don't install packages at runtime — it's slow and fragile.
 
 ### Useful Resources
 

--- a/SILVA_MIGRATION_GUIDE.md
+++ b/SILVA_MIGRATION_GUIDE.md
@@ -3,7 +3,7 @@
 A step-by-step guide for transforming open-source computational biology tools into Silva-runnable workflows for the Potter platform.
 
 **Authors:** Dev-App Team, Chiral Inc.
-**Last Updated:** March 2026
+**Last Updated:** June 2026
 
 ---
 
@@ -25,7 +25,7 @@ A step-by-step guide for transforming open-source computational biology tools in
 
 ### What is Silva?
 
-Silva is Chiral's workflow execution system. It runs multi-step computational pipelines inside isolated Docker containers. Each pipeline step is defined as a **numbered job folder** containing a configuration file (`@job.toml`) and shell scripts. Silva manages execution order, dependency resolution, and file passing between steps.
+Silva is Chiral's workflow execution system. It runs multi-step computational pipelines inside isolated Docker containers. Each pipeline step is defined as a **numbered job folder** containing a `.chiral/job.toml` configuration file and shell scripts. Silva manages execution order, dependency resolution, and file passing between steps.
 
 - **GitHub:** https://github.com/chiral-data/silva
 - **Reference workflows:** https://github.com/chiral-data/collab-workflows
@@ -50,19 +50,21 @@ Discovery → Analysis → Silva Workflow → Verification → Potter Migration
 
 ### Workflow Structure
 
-A Silva workflow is a directory containing numbered job folders. Each job folder has a `@job.toml` config and associated scripts.
+A Silva workflow is a directory containing numbered job folders and a `.chiral/workflow.toml` that defines the pipeline DAG and shared parameters. Each job folder has its own `.chiral/job.toml` config and associated scripts.
 
 ```
 my-workflow/
+├── .chiral/
+│   └── workflow.toml       ← Workflow-level config (DAG + shared params)
 ├── input_files/            ← User drops input files here
-├── global_params.json      ← Shared parameters across all jobs
 ├── 01_first_step/
-│   ├── @job.toml
+│   ├── .chiral/
+│   │   └── job.toml        ← Job-specific config
 │   ├── run.sh
 │   └── outputs/
 ├── 02_second_step/
-│   ├── @job.toml
-│   ├── params.json
+│   ├── .chiral/
+│   │   └── job.toml
 │   ├── pre_run.sh
 │   ├── run.sh
 │   ├── my_script.py
@@ -72,61 +74,94 @@ my-workflow/
 └── README.md
 ```
 
-### @job.toml — The Job Configuration File
+### workflow.toml — The Workflow Configuration File
 
-Every job folder must contain a `@job.toml` file. This declares what the job needs and produces.
+The `.chiral/workflow.toml` at the workflow root defines the pipeline name, the dependency graph (DAG), and shared parameters available to all jobs.
 
 ```toml
-# Dependencies: which previous jobs must complete first
-depends_on = ["01_first_step"]
+name = "My Workflow"
+description = "Brief description of what this workflow does"
 
-# What files this job reads from previous jobs' outputs
-inputs = ["data.csv"]
+[dependencies]
+02_second_step = ["01_first_step"]
+03_third_step  = ["02_second_step"]
 
-# What files this job produces
-outputs = ["result.csv", "plot.png"]
+[params.input_file]
+type    = "string"
+default = "input.sdf"
+hint    = "Input file name"
 
-# Docker image to run inside
+[params.threshold]
+type    = "float"
+default = 0.5
+hint    = "Filtering threshold"
+```
+
+### job.toml — The Job Configuration File
+
+Every job folder must contain a `.chiral/job.toml` file. This declares what the job needs, produces, and which container to run in.
+
+```toml
+name        = "Second Step"
+description = "Process the input data"
+inputs      = ["data.csv"]
+outputs     = ["result.csv", "plot.png"]
+
 [container]
-docker_image = "python:3.11-slim"
+image = "python:3.11-slim"
 
-# Scripts to execute (in order: pre → run → post)
 [scripts]
 pre = "pre_run.sh"    # Optional: install dependencies
 run = "run.sh"         # Required: main execution
-# post = "post_run.sh" # Optional: cleanup
+
+[params.threshold]
+type    = "float"
+default = 0.5
+hint    = "Filtering threshold"
+env     = "PARAM_THRESHOLD"
 ```
 
-**Key fields explained:**
+**Key fields in job.toml:**
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `depends_on` | No | List of job folder names that must finish before this one starts |
+| `name` | Yes | Human-readable name for this job |
 | `inputs` | No | List of filenames this job needs. Silva copies them from dependency outputs into `./inputs/` |
 | `outputs` | Yes | List of filenames this job produces. Must be written to `./outputs/` |
-| `[container].docker_image` | Yes | Docker image name and tag |
+| `[container].image` | Yes | Docker image name and tag |
 | `[scripts].pre` | No | Runs before `run`. Typically installs pip packages |
 | `[scripts].run` | Yes | Main execution script |
-| `[scripts].post` | No | Runs after `run`. Cleanup or post-processing |
+| `[params.*].env` | No | Maps the parameter to an environment variable (e.g., `PARAM_THRESHOLD`) |
+
+> **Note:** Job dependencies are declared centrally in `workflow.toml` under `[dependencies]`, not in individual `job.toml` files.
 
 ### File Passing Between Jobs
 
 Silva uses a simple convention for passing data between jobs:
 
 - Each job writes its output files to `./outputs/`
-- Downstream jobs declare `depends_on` and `inputs` in their `@job.toml`
+- Downstream jobs declare `inputs` in their `.chiral/job.toml` (dependencies are set in `workflow.toml`)
 - Silva automatically copies the matching output files into `./inputs/` of the dependent job
 
 ```
 01_prepare/outputs/data.csv  →  02_process/inputs/data.csv
 ```
 
-### Parameters: global_params.json vs params.json
+### Parameters
 
-- **`global_params.json`** — Placed in the workflow root directory. Contains parameters shared across all jobs (e.g., input filenames, atom selection strings). Every job can read this from `./inputs/global_params.json` or the workflow root.
-- **`params.json`** — Placed inside a specific job folder. Contains parameters specific to that job (e.g., reference frame index, figure dimensions).
+Parameters are defined in TOML config files and passed to scripts as **environment variables**.
 
-Both are read by your Python scripts at runtime using `json.load()`.
+- **Workflow-level parameters** — Defined in `.chiral/workflow.toml` under `[params.*]`. These are shared across all jobs.
+- **Job-level parameters** — Defined in `.chiral/job.toml` under `[params.*]`. These are specific to a single job. Each parameter has an `env` field that maps it to an environment variable name (e.g., `PARAM_THRESHOLD`).
+
+Your Python scripts read parameters at runtime using `os.environ.get()`:
+
+```python
+import os
+
+threshold = float(os.environ.get("PARAM_THRESHOLD", "0.5"))
+top_n = int(os.environ.get("PARAM_TOP_N", "20"))
+```
 
 ---
 
@@ -221,7 +256,7 @@ For each node, document:
 5. **Dependencies** (which previous nodes)
 6. **Docker image** needed
 7. **Python/system packages** needed
-8. **Key parameters** (what goes in params.json)
+8. **Key parameters** (what goes in `[params.*]` with `env` mapping)
 
 **Write this out as a document and get it reviewed before you start coding.** This is the most important step — getting the node design right saves a lot of rework later.
 
@@ -236,31 +271,40 @@ For each node, document:
 ```bash
 mkdir my-workflow
 cd my-workflow
-mkdir input_files
-mkdir 01_validate_inputs 02_prepare 03_compute 04_visualize
+mkdir -p .chiral input_files
+mkdir -p 01_validate_inputs/.chiral 02_prepare/.chiral 03_compute/.chiral 04_visualize/.chiral
 ```
 
-#### 5.2 Write global_params.json
+#### 5.2 Write workflow.toml
 
-Place shared parameters in the workflow root:
+Place the workflow-level config in `.chiral/workflow.toml`:
 
-```json
-{
-    "input_file": "input.sdf",
-    "output_format": "csv"
-}
+```toml
+name = "My Workflow"
+description = "Brief description"
+
+[dependencies]
+02_prepare   = ["01_validate_inputs"]
+03_compute   = ["02_prepare"]
+04_visualize = ["03_compute"]
+
+[params.input_file]
+type    = "string"
+default = "input.sdf"
+hint    = "Input file name"
 ```
 
 #### 5.3 Implement Node 1 — Input Validation
 
 This node typically uses a lightweight image (like `ubuntu:22.04`) and just checks that files exist.
 
-**`01_validate_inputs/@job.toml`:**
+**`01_validate_inputs/.chiral/job.toml`:**
 ```toml
+name    = "Validate Inputs"
 outputs = ["input.sdf"]
 
 [container]
-docker_image = "ubuntu:22.04"
+image = "ubuntu:22.04"
 
 [scripts]
 run = "run.sh"
@@ -294,18 +338,30 @@ echo "Input validation complete."
 
 For nodes that run Python code:
 
-**`02_compute/@job.toml`:**
+**`02_compute/.chiral/job.toml`:**
 ```toml
-depends_on = ["01_validate_inputs"]
-inputs = ["input.sdf"]
+name    = "Compute"
+inputs  = ["input.sdf"]
 outputs = ["results.csv"]
 
 [container]
-docker_image = "python:3.11-slim"
+image = "python:3.11-slim"
 
 [scripts]
 pre = "pre_run.sh"
 run = "run.sh"
+
+[params.threshold]
+type    = "float"
+default = 0.5
+hint    = "Filtering threshold"
+env     = "PARAM_THRESHOLD"
+
+[params.method]
+type    = "string"
+default = "default"
+hint    = "Computation method"
+env     = "PARAM_METHOD"
 ```
 
 **`02_compute/pre_run.sh`:**
@@ -324,62 +380,16 @@ python3 compute.py
 echo "Done. Results written to outputs/"
 ```
 
-**`02_compute/params.json`:**
-```json
-{
-    "threshold": 0.5,
-    "method": "default"
-}
-```
-
 #### 5.5 Writing Standalone Python Scripts
 
-Your Python scripts should be self-contained files that:
+Your Python scripts should be self-contained files that follow these conventions:
 
-1. Read parameters from `global_params.json` and/or `params.json`
-2. Read input files from `./inputs/`
-3. Do the computation
-4. Write output files to `./outputs/`
+1. **Read parameters** from `PARAM_*` environment variables (set by Silva from `job.toml`), using `os.environ.get("PARAM_NAME", "default")` with sensible defaults.
+2. **Read input files** from `./inputs/`.
+3. **Write output files** to `./outputs/` (create the directory with `os.makedirs("./outputs", exist_ok=True)`).
+4. **Print progress** with `flush=True` so Silva can stream logs in real time.
 
-**Template:**
-
-```python
-#!/usr/bin/env python3
-"""Brief description of what this script does."""
-
-import json
-import os
-
-def load_params():
-    """Load global and local parameters."""
-    global_params = {}
-    if os.path.exists("./inputs/global_params.json"):
-        with open("./inputs/global_params.json") as f:
-            global_params = json.load(f)
-
-    local_params = {}
-    if os.path.exists("params.json"):
-        with open("params.json") as f:
-            local_params = json.load(f)
-
-    return global_params, local_params
-
-def main():
-    global_params, local_params = load_params()
-
-    # Read inputs
-    input_file = f"./inputs/{global_params.get('input_file', 'input.sdf')}"
-
-    # Do computation
-    # ... your code here ...
-
-    # Write outputs
-    os.makedirs("./outputs", exist_ok=True)
-    # ... write results to ./outputs/ ...
-
-if __name__ == "__main__":
-    main()
-```
+Browse existing workflows in this repo for concrete examples — each tool's script looks different, but the I/O conventions above are consistent.
 
 ### Docker Image Selection Guide
 
@@ -450,7 +460,7 @@ Before submitting your workflow, confirm all of the following:
 - [ ] The workflow runs from scratch with no modifications (clean `input_files/` → green checkmarks)
 - [ ] No hardcoded absolute paths in any scripts
 - [ ] All file paths use `./inputs/` and `./outputs/` conventions
-- [ ] `global_params.json` and `params.json` values are actually used (not ignored)
+- [ ] Parameters defined in `job.toml` are read correctly via `PARAM_*` environment variables
 
 ### Deliverable Proof
 
@@ -488,15 +498,17 @@ Brief description of what this workflow computes and why it's useful.
 
 ## Parameters
 
-### global_params.json
+Parameters are defined in `.chiral/workflow.toml` (shared) and `.chiral/job.toml` (per-node).
+
+### Workflow Parameters (workflow.toml)
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | ... | ... | ... | ... |
 
-### Node XX — params.json
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| ... | ... | ... | ... |
+### Node XX Parameters (job.toml)
+| Parameter | Type | Default | Env Variable | Description |
+|-----------|------|---------|--------------|-------------|
+| ... | ... | ... | `PARAM_...` | ... |
 
 ## Output Files
 - `result.csv` — Description
@@ -601,10 +613,13 @@ Build your workflow following the implementation steps in Sections 3-7 of this g
 ```bash
 # Your workflow lives here
 workflows/workflow-XXX/
+├── .chiral/
+│   └── workflow.toml
 ├── input_files/
-├── global_params.json
 ├── 01_.../
+│   └── .chiral/job.toml
 ├── 02_.../
+│   └── .chiral/job.toml
 └── README.md
 ```
 
@@ -700,7 +715,7 @@ Rongjun will review your PR and may leave comments or request changes. This is n
 ```bash
 # Make fixes
 git add .
-git commit -m "Address review: fix params.json handling in node 03"
+git commit -m "Address review: fix parameter handling in node 03"
 git push origin workflow/<tool-name>
 ```
 
@@ -793,9 +808,9 @@ git commit -m "Your message"
 
 4. **Installing packages in `run.sh` instead of `pre_run.sh`.** Package installation goes in `pre_run.sh` (the `pre` script). Keep `run.sh` for actual computation only.
 
-5. **Declaring outputs that aren't actually written.** If your `@job.toml` says `outputs = ["result.csv"]`, your script must write exactly `./outputs/result.csv`. Mismatches cause silent failures.
+5. **Declaring outputs that aren't actually written.** If your `job.toml` says `outputs = ["result.csv"]`, your script must write exactly `./outputs/result.csv`. Mismatches cause silent failures.
 
-6. **Not reading parameters from JSON.** Don't hardcode values that should come from `params.json` or `global_params.json`. The whole point is that users can modify parameters without editing code.
+6. **Not reading parameters from environment variables.** Don't hardcode values that should come from `PARAM_*` env vars (defined in `job.toml`). The whole point is that users can modify parameters without editing code.
 
 7. **Using `latest` Docker image tags.** Always pin a specific tag (e.g., `python:3.11-slim`, not `python:latest`) for reproducibility.
 


### PR DESCRIPTION
## Summary

- **New:** `AI_WORKFLOW_GUIDE.md` — practical guide for interns on using Claude Code to accelerate workflow development, covering context preparation, Dockerfile patterns, node scaffolding, Docker debugging, code review, report generation, and end-to-end testing
- **Updated:** `SILVA_MIGRATION_GUIDE.md` — replaced all old `@job.toml` / `params.json` / `global_params.json` references with the current `.chiral/workflow.toml` + `.chiral/job.toml` + `PARAM_*` env var format (all 88 nodes in the repo use this format; zero use the old one)

Closes #155

## What's in the AI Guide

1. What context to feed AI (similar examples, node proposals, tool repos, config format)
2. Dockerfile preparation (4 patterns: minimal pip, conda, GPU+cache, package patching)
3. Dockerfile testing (build, smoke test, GPU test)
4. Node structure scaffolding and node-by-node implementation
5. Per-node Docker debugging with mounted inputs/outputs
6. Code review checklist
7. Report template generation (Bootstrap 5, Plotly.js, 3Dmol.js, Mol*, SMILES-drawer)
8. End-to-end testing (Docker chain → Silva)
9. Prompt templates quick reference
10. Recommended conventions for new workflows

## Recommended conventions for new workflows

- Read inputs from `./inputs/` (not argparse)
- Write outputs to `./outputs/` (including `report.html`)
- Read parameters from `PARAM_*` environment variables
- Embed all report data inline (self-contained HTML)

## Test plan

- [x] All referenced file paths verified to exist in the repo
- [x] Config examples match actual workflow-014 and workflow-018 files
- [x] No remaining `@job.toml` / `params.json` references in migration guide
- [x] Both documents internally consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)