### PR TITLE
docs: mark workflow-026 ColabFold as complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A collection of scientific computing workflows for drug discovery, molecular ana
 23. [AI-ADMET Property Prediction](https://github.com/AliGhiami/ai-admet-chiral-workflow) — 49 ADMET property predictions with DrugBank percentile scoring and MPO-ranked HTML report by [Ali Ghiami](https://github.com/AliGhiami)
 24. [AI-Solubility Prediction](https://github.com/AliGhiami/ai-solubility-chiral-workflow) — organic solubility prediction using MIT fastsolv, ranking solvents by log(S) across temperatures for experimental candidate shortlisting by [Ali Ghiami](https://github.com/AliGhiami)
 25. [Docking Comparison: AutoDock Vina vs GNINA](workflows/workflow-025/README.md) — side-by-side virtual screening comparison with redocking QC and HTML report by [Allison Cheng](https://github.com/allisongcheng)
-26. [ColabFold Structure Prediction](workflows/workflow-026/README.md) — AlphaFold2-based 3D structure prediction via ColabFold with MSA from MMseqs2 by [johnandrian](https://github.com/johnandrian) :construction:
+26. [ColabFold Structure Prediction](workflows/workflow-026/README.md) — AlphaFold2-based 3D structure prediction via ColabFold with MSA from MMseqs2 by [johnandrian](https://github.com/johnandrian)
 27. [qPCR Primer/Probe Design](workflows/workflow-027/README.md) — end-to-end qPCR primer/probe design and validation by [ajaypavan1004](https://github.com/ajaypavan1004)
 28. Structure-to-Docking Prediction (Boltz-2 → P2Rank → Uni-Mol Docking V2) :construction:
 29. Binder Design Pipeline (RFdiffusion → ProteinMPNN → PRODIGY) :construction:


### PR DESCRIPTION
## Summary
- Remove `:construction:` flag from workflow-026 (ColabFold Structure Prediction) in README, marking it as complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)