### PR TITLE
fix(031): PET resin — tleap aromatic-ring connectivity failure

### DIFF
--- a/workflows/workflow-031/01-build-cell/build_cell.py
+++ b/workflows/workflow-031/01-build-cell/build_cell.py
@@ -76,14 +76,17 @@ def box_side_angstrom(n_chains, smiles, density_gcc, pack_frac=PACK_DENSITY_FRAC
     return side_cm * 1e8   # cm → Å
 
 
-def build_oligomer_pdb(smiles, out_pdb):
+def build_oligomer(smiles, out_pdb, out_sdf):
     from rdkit.Chem import MolFromSmiles, AddHs
     from rdkit.Chem.AllChem import EmbedMolecule, MMFFOptimizeMolecule, ETKDGv3
-    from rdkit.Chem import MolToPDBFile
+    from rdkit.Chem import MolToPDBFile, MolToMolFile
     mol = AddHs(MolFromSmiles(smiles))
     ps  = ETKDGv3(); ps.randomSeed = 42
     EmbedMolecule(mol, ps)
     MMFFOptimizeMolecule(mol)
+    # SDF keeps RDKit's exact (Kekulized) bond orders for antechamber; PDB (no
+    # bond-order field) is only used for packmol, which just needs coordinates.
+    MolToMolFile(mol, str(out_sdf))
     MolToPDBFile(mol, str(out_pdb))
     n_atoms = mol.GetNumAtoms()
     print(f"  Oligomer: {n_atoms} atoms → {out_pdb}")
@@ -92,14 +95,15 @@ def build_oligomer_pdb(smiles, out_pdb):
 
 WORKDIR = pathlib.Path(tempfile.mkdtemp(prefix="build_barrier_"))
 
-# 1. RDKit → PDB
+# 1. RDKit → PDB (for packmol) + SDF (for antechamber, preserves bond orders)
 oligomer_pdb = WORKDIR / "oligomer.pdb"
-build_oligomer_pdb(SMILES, oligomer_pdb)
+oligomer_sdf = WORKDIR / "oligomer.sdf"
+build_oligomer(SMILES, oligomer_pdb, oligomer_sdf)
 
 # 2. antechamber GAFF2 + AM1-BCC charges
 mol2 = WORKDIR / "mol.mol2"
 print(f"  $ antechamber ...")
-run(f"antechamber -i {oligomer_pdb} -fi pdb -o {mol2} -fo mol2 "
+run(f"antechamber -i {oligomer_sdf} -fi mdl -o {mol2} -fo mol2 "
     f"-c bcc -s 2 -rn UNL -at gaff2", cwd=WORKDIR)
 
 # 3. parmchk2

--- a/workflows/workflow-031/README.md
+++ b/workflows/workflow-031/README.md
@@ -56,21 +56,23 @@ simulations to reach the true Einstein (log-log slope ≈ 1) regime.
 | `PP` | propylene 5-mer | ✅ Supported |
 | `EVOH` | E/VOH 5-mer | ✅ Supported |
 | `PA6` | caprolactam 5-mer | ✅ Supported |
-| `PET` | terephthalate 5-mer | ⚠️ **Known issue — see below** |
+| `PET` | terephthalate 5-mer | ✅ Supported |
 
-### PET: tleap connectivity failure
+### PET: fixed tleap connectivity failure
 
-PET contains aromatic rings. When packmol assembles the multi-chain cell as a PDB file,
-bond-order information is lost. tleap then misidentifies the hybridisation of some ring
-carbons and exits with:
+`antechamber` previously read the RDKit-generated oligomer from a plain PDB, which has
+no bond-order field. For PET's ester carbonyl carbon this made `antechamber` guess the
+wrong hybridisation (sp3 instead of sp2) and emit a duplicate bond, which `tleap` then
+rejected:
 
 ```
 Atom .R<UNL 1>.A<C36 47> has force field coordination 4 but only 3 bonded neighbors.
 ```
 
-**Workaround (not yet automated):** switch packmol to mol2 I/O so bond types are
-preserved through the full pipeline. Until that is fixed, use `LDPE`, `PP`, `EVOH`, or
-`PA6` for automated runs. PET manual workaround tracked in the PR.
+**Fix:** `build_cell.py` now also writes the oligomer as an SDF
+(`RDKit.Chem.MolToMolFile`), which preserves RDKit's exact Kekulized bond orders, and
+feeds that to `antechamber` (`-fi mdl`) instead of the bond-order-less PDB. Packmol and
+tleap are unaffected — they still use the PDB for coordinates only.
 
 ---
 


### PR DESCRIPTION
## Summary
- `antechamber` was reading the RDKit-generated PET oligomer from a plain PDB (no bond-order field) and mistyping the ester carbonyl carbon as sp3, emitting a duplicate bond that `tleap` rejected downstream (`coordination 4 but only 3 bonded neighbors`).
- The corrupted bond was already present in the single-oligomer `mol.mol2` template, before packmol/tleap ever touch the packed cell — so the originally proposed packmol/tleap mol2-I/O fix wouldn't have addressed the root cause (details in the issue-181 comment thread).
- Fix: `build_cell.py` now also writes the oligomer as an SDF (`RDKit.Chem.MolToMolFile`, preserving RDKit's exact Kekulized bond orders) and feeds that to `antechamber` via `-fi mdl` instead of the bond-order-less PDB. Packmol and tleap are unchanged — they still use the PDB for coordinates only.
- README updated: PET now marked ✅ Supported, with the section rewritten to describe the fix.

Fixes #181