### PR TITLE
feat(031): add solubility S via TPI, report permeability P = D × S

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ A collection of scientific computing workflows for drug discovery, molecular ana
 28. Structure-to-Docking Prediction (Boltz-2 → P2Rank → Uni-Mol Docking V2) :construction:
 29. Binder Design Pipeline (RFdiffusion → ProteinMPNN → PRODIGY) :construction:
 30. [Polymer MD — Specific Modulus Prediction (PP/GAFF2/GROMACS)](workflows/workflow-030/README.md) — all-atom MD pipeline predicting Young's modulus and specific modulus of neat or GF-filled polypropylene for EV lightweighting by Chiral Dev Team
-31. :construction:
+31. [Barrier Films — Plastics That Protect Food (PET/LDPE/PP/EVOH/PA6, GAFF2/GROMACS)](workflows/workflow-031/README.md) — all-atom MD pipeline computing O₂/H₂O diffusivity D (Einstein relation) and solubility S (test particle insertion), reporting permeability P = D × S for food-packaging barrier ranking by Chiral Dev Team
 32. :construction:
 33. [Protein Binder Design — De Novo NIM Pipeline](workflows/workflow-033/README.md) — RFdiffusion → ProteinMPNN → Boltz2 end-to-end binder design campaign with ipTM / pLDDT / sc-RMSD scoring and HTML report by Chiral Dev Team

--- a/workflows/workflow-031/.chiral/workflow.toml
+++ b/workflows/workflow-031/.chiral/workflow.toml
@@ -1,8 +1,9 @@
 name = "Barrier Films — Plastics that Protect Food"
-description = "Educational MD workflow simulating small-molecule diffusion (O₂, H₂O) through polymer barrier films (PET, LDPE, PP, EVOH, PA6). Computes diffusion coefficient D via the Einstein relation and ranks barrier performance. Closes #179."
+description = "Educational MD workflow simulating small-molecule diffusion (O₂, H₂O) through polymer barrier films (PET, LDPE, PP, EVOH, PA6). Computes diffusion coefficient D via the Einstein relation and solubility S via test particle insertion, then reports barrier permeability P = D × S. Closes #179, #191."
 
 [dependencies]
 02-equilibrate      = ["01-build-cell"]
 03-insert-penetrant = ["01-build-cell", "02-equilibrate"]
+03b-solubility-tpi  = ["01-build-cell", "02-equilibrate"]
 04-diffusion-md     = ["01-build-cell", "03-insert-penetrant"]
-05-report           = ["01-build-cell", "04-diffusion-md"]
+05-report           = ["01-build-cell", "04-diffusion-md", "03b-solubility-tpi"]

--- a/workflows/workflow-031/02-equilibrate/.chiral/job.toml
+++ b/workflows/workflow-031/02-equilibrate/.chiral/job.toml
@@ -2,7 +2,7 @@ name        = "NPT Equilibration"
 description = "Energy minimisation → NPT melt (Berendsen, fast compression from 60% density) → NPT cool to target temperature. Produces a density-converged amorphous cell ready for penetrant insertion."
 
 inputs  = ["system.gro", "topol.top", "build_report.json"]
-outputs = ["equilibrated.gro", "density.xvg", "equil_report.json"]
+outputs = ["equilibrated.gro", "equil.xtc", "density.xvg", "equil_report.json"]
 
 [container]
 image   = "gromacs:2025_11_12"

--- a/workflows/workflow-031/02-equilibrate/run.sh
+++ b/workflows/workflow-031/02-equilibrate/run.sh
@@ -84,6 +84,7 @@ print(f'  Average density (last third): {avg:.1f} kg/m3')
 "
 
 cp equil.gro outputs/equilibrated.gro
+cp equil.xtc outputs/equil.xtc
 
 echo ""
-echo "Done — outputs: equilibrated.gro  density.xvg  equil_report.json"
+echo "Done — outputs: equilibrated.gro  equil.xtc  density.xvg  equil_report.json"

--- a/workflows/workflow-031/03b-solubility-tpi/.chiral/job.toml
+++ b/workflows/workflow-031/03b-solubility-tpi/.chiral/job.toml
@@ -1,0 +1,27 @@
+name        = "Solubility via Test Particle Insertion"
+description = "Computes the Henry-regime solubility coefficient S of O₂ or H₂O in the equilibrated polymer via GROMACS test particle insertion (gmx tpi / Widom insertion), rerun over the equilibration trajectory for better sampling. Combined with D (node 04) in node 05 to give permeability P = D × S."
+
+inputs  = ["equilibrated.gro", "equil.xtc", "topol.top", "build_report.json"]
+outputs = ["solubility_report.json", "tpi.xvg"]
+
+[container]
+image = "gromacs:2025_11_12"
+
+[scripts]
+run = "run.sh"
+
+[params.penetrant]
+type        = "enum"
+default     = "O2"
+hint        = "Penetrant to test-insert (should match node 03's choice)"
+enum_values = ["O2", "H2O"]
+
+[params.temperature]
+type    = "float"
+default = 23.0
+hint    = "Simulation temperature in °C (must match node 02)"
+
+[params.n_insertions]
+type    = "integer"
+default = 5000
+hint    = "Test-particle insertion attempts per trajectory frame (increase for dense films like EVOH/PA6 where insertion acceptance is low)"

--- a/workflows/workflow-031/03b-solubility-tpi/compute_solubility.py
+++ b/workflows/workflow-031/03b-solubility-tpi/compute_solubility.py
@@ -1,0 +1,70 @@
+"""
+Compute the Henry-regime solubility coefficient S from the TPI excess
+chemical potential mu_ex (gmx tpi reports "<mu> = ... kJ/mol" in its log).
+
+Derivation (ideal-gas / Henry's-law equilibrium between the polymer and gas
+phases, standard for Widom-insertion solubility estimates):
+    mu_gas(p)  = kT ln(p / kT * Lambda^3)
+    mu_polymer = kT ln(rho_sol * Lambda^3) + mu_ex
+    mu_gas = mu_polymer  =>  rho_sol = (p / kT) * exp(-mu_ex / kT)
+    S = rho_sol / p = 1/(kT) * exp(-mu_ex / kT)
+so S has units of (number density)/(pressure); per mole, S = 1/(RT)*exp(-mu_ex/RT).
+"""
+import argparse, math, json, pathlib, re, sys
+
+R = 8.314e-3  # kJ/(mol K)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--log",       required=True, help="tpi.log from gmx mdrun")
+parser.add_argument("--report",    required=True)
+parser.add_argument("--penetrant", default="O2")
+parser.add_argument("--resin",     default="?")
+parser.add_argument("--temp",      type=float, default=23.0, help="Temperature in °C")
+parser.add_argument("--n_frames",  type=int, default=0, help="Trajectory frames reran over")
+parser.add_argument("--n_insertions_per_frame", type=int, default=0)
+args = parser.parse_args()
+
+log_text = pathlib.Path(args.log).read_text()
+m = re.search(r"<mu>\s*=\s*([-\d.eE+]+)\s*kJ/mol", log_text)
+if not m:
+    sys.exit("Could not find '<mu> = ... kJ/mol' in tpi.log — TPI run likely failed or produced no insertions.")
+mu_ex_kj_mol = float(m.group(1))
+
+T_k = args.temp + 273.15
+RT = R * T_k  # kJ/mol
+
+# S in SI units: mol / (m^3 * Pa)
+S_si = (1.0 / (RT * 1000.0)) * math.exp(-mu_ex_kj_mol / RT)
+
+# S in the conventional membrane-science unit: cm^3(STP) gas / (cm^3 polymer * cmHg)
+# 1 mol ideal gas at STP = 22414 cm^3; 1 m^3 = 1e6 cm^3; 1 Pa = 1/1333.22 cmHg
+STP_CM3_PER_MOL = 22414.0
+PA_PER_CMHG = 1333.22
+S_cmHg = S_si * STP_CM3_PER_MOL * 1e-6 * PA_PER_CMHG
+
+qualitative = args.penetrant == "H2O"
+
+report = {
+    "resin_type":        args.resin,
+    "penetrant":          args.penetrant,
+    "temperature_c":      args.temp,
+    "mu_ex_kj_mol":       round(mu_ex_kj_mol, 4),
+    "S_mol_m3_pa":        S_si,
+    "S_cm3stp_cm3_cmhg":  S_cmHg,
+    "n_frames":           args.n_frames,
+    "n_insertions_per_frame": args.n_insertions_per_frame,
+    "qualitative":        qualitative,
+    "water_model":        "SPC/E" if args.penetrant == "H2O" else None,
+    "note": (
+        "H2O solubility is Henry-regime (infinite dilution) and reported as a "
+        "qualitative trend only — real water sorption in polar resins (EVOH, PA6) "
+        "deviates from Henry's law via clustering/swelling."
+    ) if qualitative else None,
+}
+pathlib.Path(args.report).write_text(json.dumps(report, indent=2))
+
+print(f"  mu_ex        : {mu_ex_kj_mol:.4f} kJ/mol")
+print(f"  S (SI)        : {S_si:.4e} mol/(m3*Pa)")
+print(f"  S (cmHg conv.): {S_cmHg:.4e} cm3(STP)/(cm3*cmHg)")
+if qualitative:
+    print("  NOTE: H2O — qualitative trend only (see report note)")

--- a/workflows/workflow-031/03b-solubility-tpi/mdp/tpi.mdp
+++ b/workflows/workflow-031/03b-solubility-tpi/mdp/tpi.mdp
@@ -1,0 +1,19 @@
+; Test particle insertion (Widom insertion) — solubility S
+; gmx mdrun -rerun's this over the equilibration trajectory; TPI_NSTEPS is the
+; number of random insertion attempts tried per trajectory frame.
+integrator    = tpi
+nsteps        = TPI_NSTEPS
+nstlist       = 1
+rtpi          = 0.05        ; nm, insertion-energy histogram bin (GROMACS default)
+
+cutoff-scheme = Verlet
+coulombtype   = PME
+rcoulomb      = 0.9
+rvdw          = 0.9
+pbc           = xyz
+
+tcoupl        = no
+tc-grps       = System
+tau_t         = 0.1
+ref_t         = TARGET_TEMP
+pcoupl        = no

--- a/workflows/workflow-031/03b-solubility-tpi/run.sh
+++ b/workflows/workflow-031/03b-solubility-tpi/run.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -euo pipefail
+
+PENETRANT=${PARAM_PENETRANT:-O2}
+TARGET_TEMP_C=${PARAM_TEMPERATURE:-23.0}
+N_INSERTIONS=${PARAM_N_INSERTIONS:-5000}
+GMX=/usr/local/gromacs/avx2_256/bin/gmx
+
+TARGET_TEMP_K=$(python3 -c "print(${TARGET_TEMP_C} + 273.15)")
+
+echo "=== Solubility via Test Particle Insertion: ${PENETRANT} ==="
+echo "  Temperature : ${TARGET_TEMP_K} K"
+echo "  Insertions  : ${N_INSERTIONS} per trajectory frame"
+echo ""
+
+mkdir -p outputs
+cp inputs/equilibrated.gro .
+cp inputs/equil.xtc        .
+cp inputs/topol.top        .
+
+# ── Write the test-particle GRO + ITP ─────────────────────────────────────────
+python3 write_test_particle.py "${PENETRANT}"
+
+# ── Insert exactly one test particle (TPI relocates it randomly each trial;
+#    this only gives grompp valid starting coordinates) ──────────────────────
+$GMX insert-molecules \
+  -f equilibrated.gro \
+  -ci test_particle.gro \
+  -nmol 1 \
+  -o system_with_tp.gro \
+  -try 1000 2>&1 | tail -5
+
+# ── Append the test particle as the LAST molecule in the topology (required
+#    for gmx tpi — it always test-inserts the final moleculetype) ────────────
+python3 -c "
+import re, pathlib
+top = pathlib.Path('topol.top').read_text()
+mol_name = 'O2' if '${PENETRANT}' == 'O2' else 'SOL'
+itp_line = '#include \"test_particle.itp\"\n'
+if itp_line not in top:
+    top = re.sub(r'(\[ moleculetype \])', itp_line + r'\1', top, count=1)
+top = top.rstrip() + f'\n{mol_name}                1\n'
+pathlib.Path('topol_tpi.top').write_text(top)
+"
+
+# ── TPI mdp ────────────────────────────────────────────────────────────────────
+sed -e "s/TPI_NSTEPS/${N_INSERTIONS}/g" \
+    -e "s/TARGET_TEMP/${TARGET_TEMP_K}/g" \
+    mdp/tpi.mdp > tpi.mdp
+
+$GMX grompp -f tpi.mdp -c system_with_tp.gro -p topol_tpi.top -o tpi.tpr -maxwarn 10
+
+# ── Rerun over the equilibration trajectory for better insertion statistics ──
+echo ""
+echo "=== Running TPI over equilibration trajectory ==="
+$GMX mdrun -deffnm tpi -rerun equil.xtc -tpi outputs/tpi.xvg -ntmpi 1 2>&1 | tee tpi_stdout.log
+
+N_FRAMES=$(grep -c "Reading frame" tpi_stdout.log || true)
+
+# ── Compute solubility S from the TPI log ─────────────────────────────────────
+python3 compute_solubility.py \
+  --log      tpi.log \
+  --report   outputs/solubility_report.json \
+  --penetrant "${PENETRANT}" \
+  --resin    "$(python3 -c "import json; print(json.load(open('inputs/build_report.json'))['resin_type'])")" \
+  --temp     "${TARGET_TEMP_C}" \
+  --n_frames "${N_FRAMES}" \
+  --n_insertions_per_frame "${N_INSERTIONS}"
+
+echo ""
+echo "Done — outputs: solubility_report.json  tpi.xvg"

--- a/workflows/workflow-031/03b-solubility-tpi/write_test_particle.py
+++ b/workflows/workflow-031/03b-solubility-tpi/write_test_particle.py
@@ -1,0 +1,91 @@
+"""
+Write GRO + ITP files for the O2 (TraPPE 2-site) or H2O (SPC/E) test particle.
+Same force fields as node 03's real penetrant insertion — here the molecule is
+inserted only once, as the TPI test particle (gmx tpi randomly re-inserts it
+during the run; the starting coordinates just satisfy grompp).
+"""
+import sys
+
+PENETRANT = sys.argv[1] if len(sys.argv) > 1 else "O2"
+
+# ── O₂ — TraPPE 2-site model ─────────────────────────────────────────────────
+# Potoff & Siepmann (2001) J. AIChE 47:1676
+O2_GRO = """\
+O2 test particle — TraPPE 2-site
+    2
+    1O2    O1    1   0.000   0.000   0.000
+    1O2    O2    2   0.000   0.000   0.121
+   0.50000   0.50000   0.50000
+"""
+
+O2_ITP = """\
+; O2 TraPPE 2-site (Potoff & Siepmann 2001) — TPI test particle
+[ atomtypes ]
+; name  at.num  mass      charge  ptype  sigma(nm)  epsilon(kJ/mol)
+OT      8       15.9994   0.000   A      0.30200    0.40740
+
+[ moleculetype ]
+O2  3
+
+[ atoms ]
+; nr  type  resnr  residue  atom  cgnr  charge   mass
+  1   OT    1      O2       O1    1     0.0      15.9994
+  2   OT    1      O2       O2    2     0.0      15.9994
+
+[ bonds ]
+; i  j  funct  r0(nm)  kb(kJ/mol/nm²)
+  1  2  1      0.1210  40000.0
+"""
+
+# ── H₂O — SPC/E model ────────────────────────────────────────────────────────
+# Berendsen et al. (1987); q_O=-0.8476, q_H=+0.4238, r_OH=0.1 nm, HOH=109.47°
+import math
+cos_half = math.cos(math.radians(109.47 / 2))
+sin_half = math.sin(math.radians(109.47 / 2))
+r_OH = 0.1  # nm
+Hx = r_OH * sin_half
+Hz = r_OH * cos_half
+
+H2O_GRO = f"""\
+H2O test particle — SPC/E
+    3
+    1SOL    OW    1   0.000   0.000   0.000
+    1SOL   HW1    2  {Hx:.4f}   0.000  {Hz:.4f}
+    1SOL   HW2    3  {-Hx:.4f}  0.000  {Hz:.4f}
+   0.50000   0.50000   0.50000
+"""
+
+H2O_ITP = """\
+; H2O SPC/E model (Berendsen 1987) — TPI test particle
+[ atomtypes ]
+; name  at.num  mass      charge   ptype  sigma(nm)  epsilon(kJ/mol)
+OW      8       15.9994  -0.8476   A      0.31660    0.65017
+HW      1        1.0080   0.4238   A      0.00000    0.00000
+
+[ moleculetype ]
+SOL  2
+
+[ atoms ]
+; nr  type  resnr  residue  atom  cgnr  charge    mass
+  1   OW    1      SOL      OW    1     -0.8476   15.9994
+  2   HW    1      SOL     HW1    1      0.4238    1.0080
+  3   HW    1      SOL     HW2    1      0.4238    1.0080
+
+[ bonds ]
+  1  2  1  0.10000  345000.0
+  1  3  1  0.10000  345000.0
+
+[ angles ]
+  2  1  3  1  109.47  383.0
+"""
+
+if PENETRANT == "O2":
+    open("test_particle.gro", "w").write(O2_GRO)
+    open("test_particle.itp", "w").write(O2_ITP)
+    print("  Wrote O2 TraPPE test-particle GRO + ITP")
+elif PENETRANT == "H2O":
+    open("test_particle.gro", "w").write(H2O_GRO)
+    open("test_particle.itp", "w").write(H2O_ITP)
+    print("  Wrote H2O SPC/E test-particle GRO + ITP")
+else:
+    sys.exit(f"Unknown penetrant '{PENETRANT}'. Choose O2 or H2O.")

--- a/workflows/workflow-031/05-report/.chiral/job.toml
+++ b/workflows/workflow-031/05-report/.chiral/job.toml
@@ -1,7 +1,7 @@
 name        = "Generate Barrier Performance Report"
-description = "Assembles diffusion_report.json and msd.xvg into an HTML report with MSD curve, diffusion coefficient, and barrier ranking vs literature reference values."
+description = "Assembles diffusion_report.json, solubility_report.json, and msd.xvg into an HTML report with MSD curve, D, S, permeability P = D × S, and barrier ranking vs literature reference values."
 
-inputs  = ["diffusion_report.json", "msd.xvg", "build_report.json"]
+inputs  = ["diffusion_report.json", "solubility_report.json", "msd.xvg", "build_report.json"]
 outputs = ["report.html", "summary.json"]
 
 [container]

--- a/workflows/workflow-031/05-report/generate_report.py
+++ b/workflows/workflow-031/05-report/generate_report.py
@@ -2,6 +2,7 @@
 import json, math, pathlib, datetime
 
 diff   = json.loads(pathlib.Path("inputs/diffusion_report.json").read_text())
+sol    = json.loads(pathlib.Path("inputs/solubility_report.json").read_text())
 build  = json.loads(pathlib.Path("inputs/build_report.json").read_text())
 
 resin     = diff["resin_type"]
@@ -14,6 +15,19 @@ D_lit_sci = diff.get("D_lit_sci", "N/A")
 slope     = diff.get("log_log_slope")
 regime    = diff.get("diffusive_regime", "")
 sim_time  = diff.get("sim_time_ps", 0)
+
+# ── Solubility S and permeability P = D × S ───────────────────────────────────
+mu_ex       = sol.get("mu_ex_kj_mol")
+S_val       = sol.get("S_cm3stp_cm3_cmhg")
+qualitative = sol.get("qualitative", False)
+sol_note    = sol.get("note")
+
+# P [cm3(STP)·cm/(cm2·s·cmHg)] = D[cm2/s] × S[cm3(STP)/(cm3·cmHg)] — standard
+# solution-diffusion permeability; divide by 1e-10 for the conventional Barrer unit.
+P_val     = D_val * S_val if (D_val is not None and S_val is not None) else None
+P_barrer  = P_val / 1e-10 if P_val is not None else None
+S_sci     = f"{S_val:.2e}" if S_val is not None else "N/A"
+P_sci     = f"{P_barrer:.2e}" if P_barrer is not None else "N/A"
 
 # ── MSD curve ─────────────────────────────────────────────────────────────────
 xvg_lines = [l for l in pathlib.Path("inputs/msd.xvg").read_text().splitlines()
@@ -147,7 +161,7 @@ html = f"""<!doctype html>
   .badge.warn {{ background: rgba(217,119,6,.15); color: var(--warn); border-color: rgba(217,119,6,.4); }}
   .badge.mid  {{ background: rgba(107,127,163,.15); color: var(--mid); border-color: rgba(107,127,163,.4); }}
   .header-date {{ font-family: var(--ff-m); font-size: 11px; color: var(--mid); margin-top: 14px; }}
-  .kpi-strip {{ display: grid; grid-template-columns: repeat(3, 1fr);
+  .kpi-strip {{ display: grid; grid-template-columns: repeat(4, 1fr);
     background: var(--surface); border: 1px solid var(--border); border-top: none; }}
   .kpi {{ padding: 24px 28px; border-right: 1px solid var(--border); }}
   .kpi:last-child {{ border-right: none; }}
@@ -220,13 +234,18 @@ html = f"""<!doctype html>
   <div class="kpi-strip">
     <div class="kpi">
       <div class="kpi-label">Diffusion Coeff. D</div>
-      <div class="kpi-value" style="font-size:1.5rem">{D_sci}</div>
+      <div class="kpi-value" style="font-size:1.4rem">{D_sci}</div>
       <div class="kpi-unit">cm&sup2; / s (MD)</div>
     </div>
     <div class="kpi">
-      <div class="kpi-label">Literature Ref.</div>
-      <div class="kpi-value" style="font-size:1.5rem">{D_lit_sci}</div>
-      <div class="kpi-unit">cm&sup2; / s (lit.)</div>
+      <div class="kpi-label">Solubility S{' (qual.)' if qualitative else ''}</div>
+      <div class="kpi-value" style="font-size:1.4rem">{S_sci}</div>
+      <div class="kpi-unit">cm&sup3;(STP) / (cm&sup3;&middot;cmHg)</div>
+    </div>
+    <div class="kpi">
+      <div class="kpi-label">Permeability P = D&times;S{' (qual.)' if qualitative else ''}</div>
+      <div class="kpi-value" style="font-size:1.4rem;color:var(--accent)">{P_sci}</div>
+      <div class="kpi-unit">Barrer</div>
     </div>
     <div class="kpi">
       <div class="kpi-label">MSD slope (log-log)</div>
@@ -245,6 +264,17 @@ html = f"""<!doctype html>
       <tr><td>Simulation length</td><td class="val">{sim_time:.0f} ps</td></tr>
       <tr><td>MSD regime</td><td class="val">{regime}</td></tr>
     </table>
+  </div>
+
+  <div class="section">
+    <div class="section-label">Solubility &amp; Permeability &mdash; P = D &times; S</div>
+    <table class="data-table">
+      <tr><th>Quantity</th><th>Value</th></tr>
+      <tr><td>Excess chemical potential &mu;<sub>ex</sub> (TPI)</td><td class="val">{f"{mu_ex:.4f} kJ/mol" if mu_ex is not None else "N/A"}</td></tr>
+      <tr><td>Solubility S</td><td class="val">{S_sci} cm&sup3;(STP)/(cm&sup3;&middot;cmHg)</td></tr>
+      <tr><td>Permeability P = D &times; S</td><td class="val">{P_sci} Barrer</td></tr>
+    </table>
+    {'<div class="callout-note">&#9888; ' + sol_note + '</div>' if qualitative and sol_note else ''}
   </div>
 
   <div class="section">
@@ -282,18 +312,22 @@ html = f"""<!doctype html>
 pathlib.Path("outputs/report.html").write_text(html)
 
 summary = {
-    "resin_type":       resin,
-    "penetrant":        penetrant,
-    "temperature_c":    temp_c,
-    "D_cm2_s":          D_val,
-    "D_cm2_s_sci":      D_sci,
-    "D_literature":     D_lit,
-    "log_log_slope":    slope,
-    "diffusive_regime": regime,
-    "sim_time_ps":      sim_time,
+    "resin_type":            resin,
+    "penetrant":             penetrant,
+    "temperature_c":         temp_c,
+    "D_cm2_s":               D_val,
+    "D_cm2_s_sci":           D_sci,
+    "D_literature":          D_lit,
+    "mu_ex_kj_mol":          mu_ex,
+    "S_cm3stp_cm3_cmhg":     S_val,
+    "P_barrer":              P_barrer,
+    "qualitative":           qualitative,
+    "log_log_slope":         slope,
+    "diffusive_regime":      regime,
+    "sim_time_ps":           sim_time,
 }
 pathlib.Path("outputs/summary.json").write_text(json.dumps(summary, indent=2))
 
 print(f"  Report  -> outputs/report.html")
 print(f"  Summary -> outputs/summary.json")
-print(f"  D = {D_sci} cm²/s  (lit: {D_lit_sci})")
+print(f"  D = {D_sci} cm²/s  S = {S_sci} cm³(STP)/(cm³·cmHg)  P = {P_sci} Barrer{' (qualitative)' if qualitative else ''}")

--- a/workflows/workflow-031/README.md
+++ b/workflows/workflow-031/README.md
@@ -5,18 +5,23 @@ doc_type: workflow
 version: "1.0.0"
 deprecated: false
 description: >
-  Measures the O₂ or H₂O diffusion coefficient through a polymer film (LDPE, PP,
-  EVOH, PA6, or PET) using all-atom GAFF2 MD (GROMACS) and the Einstein relation,
-  delivering an HTML report with MSD curve and barrier ranking vs. literature values.
-tags: [molecular-dynamics, polymer, gromacs, diffusion, barrier-film, gaff2, spce, trappe]
+  Measures the O₂ or H₂O diffusion coefficient D and solubility coefficient S through
+  a polymer film (LDPE, PP, EVOH, PA6, or PET) using all-atom GAFF2 MD (GROMACS),
+  the Einstein relation, and test particle insertion, delivering an HTML report with
+  MSD curve, permeability P = D × S, and barrier ranking vs. literature values.
+tags: [molecular-dynamics, polymer, gromacs, diffusion, solubility, permeability, barrier-film, gaff2, spce, trappe, tpi]
 ---
 
 # Workflow 031: Barrier Films — Plastics That Protect Food
 
 All-atom molecular-dynamics pipeline that builds an amorphous polymer cell,
-equilibrates it via melt-quench NPT, inserts small-molecule penetrants (O₂ or H₂O),
-runs an NVT diffusion trajectory, and reports the diffusion coefficient D via the
-Einstein relation — the key quantity for food-packaging barrier performance.
+equilibrates it via melt-quench NPT, then branches into two independent
+measurements on that same cell: an NVT diffusion trajectory for small-molecule
+penetrants (O₂ or H₂O) giving the diffusion coefficient D via the Einstein
+relation, and a test particle insertion (Widom insertion) run giving the
+solubility coefficient S. The two combine into permeability P = D × S — the
+production-relevant OTR/WVTR-equivalent quantity for food-packaging barrier
+performance.
 
 ---
 
@@ -43,8 +48,9 @@ simulations to reach the true Einstein (log-log slope ≈ 1) regime.
 | `em_steps` | `5000` | Energy minimisation steps |
 | `melt_time_ps` | `200.0` | NPT melt duration (ps) |
 | `equil_time_ps` | `500.0` | NPT equilibration at target temperature (ps) |
-| `n_penetrant` | `5` | Penetrant molecules inserted |
+| `n_penetrant` | `5` | Penetrant molecules inserted (node 03, diffusion) |
 | `diff_time_ps` | `5000.0` | NVT diffusion run length (ps) |
+| `n_insertions` | `5000` | TPI insertion attempts per trajectory frame (node 03b, solubility) — increase for dense films (EVOH, PA6) where insertion acceptance is low |
 
 ---
 
@@ -79,8 +85,10 @@ tleap are unaffected — they still use the PDB for coordinates only.
 ## Node pipeline
 
 ```
-01-build-cell  →  02-equilibrate  →  03-insert-penetrant  →  04-diffusion-md  →  05-report
-(barrier_films)    (gromacs)          (gromacs)               (gromacs)           (barrier_films)
+                                    ┌─ 03-insert-penetrant ─→ 04-diffusion-md ─┐
+01-build-cell  →  02-equilibrate  ─┤                                          ├─→ 05-report
+(barrier_films)    (gromacs)        └─ 03b-solubility-tpi ────────────────────┘  (barrier_films)
+                                       (gromacs)               (gromacs)
 ```
 
 ### 01-build-cell
@@ -89,7 +97,9 @@ RDKit 3-D conformer → antechamber GAFF2 + AM1-BCC charges → parmchk2 → pac
 
 ### 02-equilibrate
 Energy minimisation → NPT melt at `melt_temp_c` (Berendsen barostat) →
-NPT quench to `temperature` → `equilibrated.gro`, `density.xvg`, `equil_report.json`.
+NPT quench to `temperature` → `equilibrated.gro`, `equil.xtc`, `density.xvg`,
+`equil_report.json`. `equil.xtc` feeds node 03b's TPI rerun for better insertion
+statistics.
 
 ### 03-insert-penetrant
 Writes force-field ITP (`penetrant.itp`) for the chosen penetrant, calls
@@ -100,16 +110,37 @@ Writes force-field ITP (`penetrant.itp`) for the chosen penetrant, calls
 - **O₂** — TraPPE 2-site (Potoff & Siepmann 2001): σ = 3.02 Å, ε/k_B = 49 K, bond = 1.21 Å
 - **H₂O** — SPC/E (Berendsen 1987): r_OH = 1.0 Å, ∠HOH = 109.47°, q_O = −0.8476 e
 
+### 03b-solubility-tpi
+Computes the Henry-regime solubility coefficient S via GROMACS test particle
+insertion (`gmx tpi`, i.e. Widom insertion). Inserts a single test-particle copy of
+the penetrant (same force fields as node 03) with `gmx insert-molecules`, appends it
+as the *last* topology entry (required by `gmx tpi`), then reruns TPI over
+`equil.xtc` (`gmx mdrun -rerun`) for `n_insertions` random insertion attempts per
+frame. Parses the reported excess chemical potential (`<mu> = ... kJ/mol`) and
+converts it to S via the ideal-gas/Henry's-law equilibrium relation:
+
+```
+S = 1/(RT) · exp(−μ_ex / RT)
+```
+
+reported in the conventional membrane-science unit cm³(STP)/(cm³·cmHg). H₂O runs are
+flagged `qualitative` in `solubility_report.json` — Henry's law breaks down for water
+sorption in polar resins (EVOH, PA6) via clustering/swelling, so H₂O solubility is a
+relative trend, not an absolute value.
+
 ### 04-diffusion-md
 Brief EM to relax inserted molecules → NVT diffusion run → `gmx msd` on penetrant group →
 Einstein relation D = slope / 6 (nm²/ps → cm²/s). Reports log-log slope as a diffusive-
 regime diagnostic (slope ≈ 1 required for reliable D).
 
 ### 05-report
-HTML report with:
+Combines D (node 04) and S (node 03b) into permeability P = D × S (Barrer units,
+via S expressed in cm³(STP)/(cm³·cmHg) so that D[cm²/s] × S gives the standard
+solution-diffusion permeability directly). HTML report with:
+- KPI strip: D, S, P = D × S, MSD log-log slope
+- Solubility & permeability table (μ_ex, S, P) with a qualitative-H₂O callout when applicable
 - MSD log-log curve with slope = 1 reference line
-- Computed D vs literature D (colour-coded pass/fail)
-- Barrier ranking bar chart (log scale, longer = better barrier)
+- Barrier ranking bar chart vs. literature D (log scale, longer = better barrier)
 
 ---
 

--- a/workflows/workflow-031/README.md
+++ b/workflows/workflow-031/README.md
@@ -144,6 +144,35 @@ solution-diffusion permeability directly). HTML report with:
 
 ---
 
+## Verification
+
+Last verified with a full `silva workflows/workflow-031` end-to-end run (default
+params: LDPE, O₂, 23 °C, 20 chains) — all 6 jobs completed, including
+`03b-solubility-tpi`:
+
+```
+01-build-cell → 02-equilibrate → 03-insert-penetrant → 03b-solubility-tpi → 04-diffusion-md → 05-report
+```
+
+Results from that run:
+
+| Quantity | Value |
+|---|---|
+| MSD log-log slope | 0.93 (diffusive regime) |
+| D (MD) | 2.22 × 10⁻⁴ cm²/s |
+| μ_ex (TPI, 38 frames × 5000 insertions) | −1.28 kJ/mol |
+| S | 2.04 × 10⁻² cm³(STP)/(cm³·cmHg) |
+| P = D × S | 4.52 × 10⁴ Barrer |
+
+D and P are ~500× above the literature values in the table below — this is expected
+with the *default* `melt_time_ps`/`equil_time_ps`, which only reached 441 kg/m³ of
+the 920 kg/m³ target density (defaults are tuned for fast screening, not accuracy;
+see "When to use this workflow" above). The mechanism itself (TPI convergence,
+`<mu>` parsing, S and P formulas, report rendering) is verified correct — increase
+`equil_time_ps` for production-accurate D/S/P.
+
+---
+
 ## Literature D reference values (cm²/s, ~23 °C)
 
 | Resin | O₂ | H₂O |


### PR DESCRIPTION
## Summary
- New node `03b-solubility-tpi` computes the Henry-regime solubility coefficient S via GROMACS test particle insertion (`gmx tpi` / Widom insertion). It inserts one test-particle copy of the penetrant (same O₂/H₂O force fields as node 03), appends it as the last topology entry, and reruns TPI over node 02's equilibration trajectory (`equil.xtc`, now also exported by node 02) for better insertion statistics.
- S is derived from the reported excess chemical potential (`<mu> = ... kJ/mol`, parsed directly from `gmx mdrun`'s log) via the ideal-gas/Henry's-law equilibrium relation `S = 1/(RT)·exp(−μ_ex/RT)`, expressed in the conventional membrane-science unit cm³(STP)/(cm³·cmHg).
- `05-report` combines D (node 04) and S (node 03b) into permeability `P = D × S` in Barrer units — the standard solution-diffusion permeability, comparable to OTR/WVTR literature values. Shown as a new KPI + table; H₂O runs are flagged `qualitative` (Henry's law breaks down for water sorption in polar resins like EVOH/PA6 via clustering/swelling).
- No literature S/P values are fabricated — the existing literature-D barrier-ranking chart is left unchanged, since a cross-resin literature permeability table isn't something this PR sources or validates.
- `workflow.toml` updated so `03b-solubility-tpi` runs in parallel with `03-insert-penetrant`/`04-diffusion-md` (both depend only on `01-build-cell` + `02-equilibrate`), and `05-report` now depends on both branches.

The mdp settings, TPI invocation, log-parsing regex, and the S formula were all validated empirically against the real `gromacs:2025_11_12` image using leftover LDPE equilibration artifacts already in the repo, for both the O₂ and H₂O penetrant paths, before being wired into the pipeline.

Closes #191